### PR TITLE
add .rdfxml and .ttl for some LoC records, and some LoC record cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ group :development do
   gem 'yard' # for documentation
   gem 'rubocop'
   gem 'rubocop-rspec'
-  # Use faraday for making HTTP requests
-  gem 'faraday'
+  gem 'faraday' # Used for HTTP (for SRU queries for LoC records)
 end
 
 # To use a debugger

--- a/README.md
+++ b/README.md
@@ -56,15 +56,20 @@ xxx.ttl is a turtle representation of the same data as the .rdfxml file -- provi
 
 The specific marc records were chosen to try to exercise different wrinkles in work/instance information present in a single marc record.  As new work-instance wrinkles are surfaced, marc records and specs should be added to the project.
 
-# Importing LOC Records via SRU
+# Importing LoC Bib marcxml Records via SRU
 
 1. Create a csv documents in the /docs folder:
     /import/m2b-classes.csv
         With header columns 'className' and 'bibid'
-    /import/m2b-properties.csv with head
+    /import/m2b-properties.csv
         With header columns 'propertyName' and 'bibid'
 
-2. In the /lib folder 'ruby m2b_csv.rb' and records from your favorite SRU service will automatically be populated within directories in the fixtures folder.
+2. From within the /lib folder:
+
+```bash
+ 'ruby m2b_csv.rb'
+```
+  and marcxml records from the LoC SRU service will be written to spec/fixtures/loc/(className|propertyName)/(bibid).marcxml.
 
 # Working with other converters
 

--- a/lib/m2b_csv.rb
+++ b/lib/m2b_csv.rb
@@ -5,7 +5,10 @@ require 'fileutils'
 ##
 # Run this in the lib folder to get classes, properties and their bibids from a csv file
 #   with headers: className, bibid or propertyName, bibid
-# #
+#
+# TODO:  SRU url should be in config file
+# TODO:  should only expect a single csv file as input, not two
+# TODO:  name of input csv file should be in config file??
 class M2bCSV
   def m2b_classes_dir
     "../import/m2b-classes.csv".to_s
@@ -32,6 +35,7 @@ class M2bCSV
   end
 
   def loc_sru_url
+    # TODO:  hardcoded SRU url should be in config file
     'http://lx2.loc.gov:210/LCDB?operation=searchRetrieve&recordSchema=marcxml&maximumRecords=1&query=rec.id'
   end
 

--- a/spec/fixtures/loc/m2b-classes/Agent/11187857.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Agent/11187857.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02911cas a2200685 a 4500</leader>
   <controlfield tag="001">11187857</controlfield>
   <controlfield tag="005">20140912075312.0</controlfield>
@@ -238,4 +238,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11187857</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Annotation/13428604.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Annotation/13428604.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02045cam a22002894a 4500</leader>
   <controlfield tag="001">13428604</controlfield>
   <controlfield tag="005">20040617133553.0</controlfield>
@@ -90,4 +90,4 @@
     <subfield code="3">Table of contents</subfield>
     <subfield code="u">http://www.loc.gov/catdir/toc/ecip0412/2003026721.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13428604</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Arrangement/11628622.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Arrangement/11628622.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>07792ckc a2201081 a 4500</leader>
   <controlfield tag="001">11628622</controlfield>
   <controlfield tag="005">20150626082430.0</controlfield>
@@ -386,4 +386,4 @@
     <subfield code="v">obj.</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11628622</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Audio/14480689.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Audio/14480689.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02093cam a22004095i 4500</leader>
   <controlfield tag="001">14480689</controlfield>
   <controlfield tag="005">20150728185615.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="k">Selections.</subfield>
     <subfield code="l">English</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14480689</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Authority/13894436.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Authority/13894436.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01971cam a22004334a 4500</leader>
   <controlfield tag="001">13894436</controlfield>
   <controlfield tag="005">20100120140825.0</controlfield>
@@ -136,4 +136,4 @@
     <subfield code="o">am</subfield>
     <subfield code="p">00107689771</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13894436</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Cartography/5485844.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Cartography/5485844.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01635cem a2200385 a 4500</leader>
   <controlfield tag="001">5485844</controlfield>
   <controlfield tag="005">20130501114526.0</controlfield>
@@ -114,4 +114,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5485844</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Classification/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Classification/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/CoverArt/16574557.marcxml
+++ b/spec/fixtures/loc/m2b-classes/CoverArt/16574557.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03022cam a2200481 i 4500</leader>
   <controlfield tag="001">16574557</controlfield>
   <controlfield tag="005">20110725131618.0</controlfield>
@@ -150,4 +150,4 @@
     <subfield code="3">Cover image</subfield>
     <subfield code="u">http://catalogimages.wiley.com/images/db/jimages/9780470527641.jpg</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16574557</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Dataset/17082740.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Dataset/17082740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01863cam a2200385 a 4500</leader>
   <controlfield tag="001">17082740</controlfield>
   <controlfield tag="005">20120215113723.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1205/2011276039-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17082740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Electronic/16697173.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Electronic/16697173.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02039cas a2200505 a 4500</leader>
   <controlfield tag="001">16697173</controlfield>
   <controlfield tag="005">20141025155915.0</controlfield>
@@ -172,4 +172,4 @@
     <subfield code="a">cf18 2011-05-09 to cf21</subfield>
     <subfield code="g">cf21 2011-05-26 to Ser.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16697173</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Family/15875548.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Family/15875548.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01116cam a22002894a 4500</leader>
   <controlfield tag="001">15875548</controlfield>
   <controlfield tag="005">20150423131224.0</controlfield>
@@ -86,4 +86,4 @@
     <subfield code="y">20th century</subfield>
     <subfield code="x">History and criticism.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15875548</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Identifier/17387996.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Identifier/17387996.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01727cas a2200409 i 4500</leader>
   <controlfield tag="001">17387996</controlfield>
   <controlfield tag="005">20140814075250.0</controlfield>
@@ -128,4 +128,4 @@
   <datafield tag="963" ind1=" " ind2=" ">
     <subfield code="a">huang@untestedideas.org</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17387996</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Instance/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Instance/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Instance/15716616.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Instance/15716616.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01847cas a22004697a 4500</leader>
   <controlfield tag="001">15716616</controlfield>
   <controlfield tag="005">20130322075551.0</controlfield>
@@ -142,4 +142,4 @@
     <subfield code="g">xf12 2009-07-06</subfield>
     <subfield code="c">xf12 2009-07-06 to Ser</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15716616</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Integrating/15566467.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Integrating/15566467.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03514cai a2200661 a 4500</leader>
   <controlfield tag="001">15566467</controlfield>
   <controlfield tag="005">20150522075149.0</controlfield>
@@ -217,4 +217,4 @@
     <subfield code="a">lcwa0003</subfield>
     <subfield code="e">lcwa</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15566467</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/IntendedAudience/15628464.marcxml
+++ b/spec/fixtures/loc/m2b-classes/IntendedAudience/15628464.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02363cam a22004214a 4500</leader>
   <controlfield tag="001">15628464</controlfield>
   <controlfield tag="005">20101124161102.0</controlfield>
@@ -138,4 +138,4 @@
     <subfield code="d">1929-</subfield>
     <subfield code="t">Physics science projects using the scientific method.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15628464</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Jurisdiction/11446720.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Jurisdiction/11446720.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01384cas a22003377a 4500</leader>
   <controlfield tag="001">11446720</controlfield>
   <controlfield tag="005">20130121075155.0</controlfield>
@@ -96,4 +96,4 @@
     <subfield code="h">Microfiche (o) 95/62408 (H)</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11446720</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Language/5485844.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Language/5485844.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01635cem a2200385 a 4500</leader>
   <controlfield tag="001">5485844</controlfield>
   <controlfield tag="005">20130501114526.0</controlfield>
@@ -114,4 +114,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5485844</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Manuscript/13294949.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Manuscript/13294949.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02105ctm a22004695a 4500</leader>
   <controlfield tag="001">13294949</controlfield>
   <controlfield tag="005">20070826133326.0</controlfield>
@@ -141,4 +141,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13294949</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Meeting/13673856.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Meeting/13673856.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01736cam a22003254a 4500</leader>
   <controlfield tag="001">13673856</controlfield>
   <controlfield tag="005">20070824185958.0</controlfield>
@@ -106,4 +106,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13673856</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/MixedMaterial/14923309.marcxml
+++ b/spec/fixtures/loc/m2b-classes/MixedMaterial/14923309.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03469cpcaa2200589 a 4500</leader>
   <controlfield tag="001">14923309</controlfield>
   <controlfield tag="005">20120329154408.0</controlfield>
@@ -191,4 +191,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">mss/ead</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14923309</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Monograph/3788341.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Monograph/3788341.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00846cam a2200253 a 4500</leader>
   <controlfield tag="001">3788341</controlfield>
   <controlfield tag="005">20040305100939.0</controlfield>
@@ -77,4 +77,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3788341</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/MovingImage/11515605.marcxml
+++ b/spec/fixtures/loc/m2b-classes/MovingImage/11515605.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04266cgm a2200649 i 4500</leader>
   <controlfield tag="001">11515605</controlfield>
   <controlfield tag="005">20110725102849.0</controlfield>
@@ -197,4 +197,4 @@
     <subfield code="h">FBC 1867 (ref print)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11515605</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Multimedia/17432593.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Multimedia/17432593.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03956cam a2200445 i 4500</leader>
   <controlfield tag="001">17432593</controlfield>
   <controlfield tag="005">20130604182306.0</controlfield>
@@ -147,4 +147,4 @@
     <subfield code="a">Bull, Phil,</subfield>
     <subfield code="e">author.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17432593</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/NotatedMusic/16997191.marcxml
+++ b/spec/fixtures/loc/m2b-classes/NotatedMusic/16997191.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00912ccm a22002775i 4500</leader>
   <controlfield tag="001">16997191</controlfield>
   <controlfield tag="005">20111118141059.0</controlfield>
@@ -81,4 +81,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">Thames Television, ltd.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16997191</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Organization/17159572.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Organization/17159572.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02494cam a2200433 a 4500</leader>
   <controlfield tag="001">17159572</controlfield>
   <controlfield tag="005">20120922113043.0</controlfield>
@@ -150,4 +150,4 @@
   <datafield tag="923" ind1=" " ind2=" ">
     <subfield code="s">CCG</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17159572</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Person/15599751.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Person/15599751.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01787cam a22004217a 4500</leader>
   <controlfield tag="001">15599751</controlfield>
   <controlfield tag="005">20120719124759.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="i">.R67 2009</subfield>
     <subfield code="t">Copy 1</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15599751</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Place/13686297.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Place/13686297.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01557cam a2200409 a 4500</leader>
   <controlfield tag="001">13686297</controlfield>
   <controlfield tag="005">20070825192306.0</controlfield>
@@ -139,4 +139,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13686297</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Provider/11446720.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Provider/11446720.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01384cas a22003377a 4500</leader>
   <controlfield tag="001">11446720</controlfield>
   <controlfield tag="005">20130121075155.0</controlfield>
@@ -96,4 +96,4 @@
     <subfield code="h">Microfiche (o) 95/62408 (H)</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11446720</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Review/4934508.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Review/4934508.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01867cam a2200325 a 4500</leader>
   <controlfield tag="001">4934508</controlfield>
   <controlfield tag="005">20050524180354.0</controlfield>
@@ -94,4 +94,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4934508</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Serial/11294554.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Serial/11294554.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01407cas a22003497a 4500</leader>
   <controlfield tag="001">11294554</controlfield>
   <controlfield tag="005">20091125050316.0</controlfield>
@@ -107,4 +107,4 @@
     <subfield code="h">Newspaper 7114-X</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11294554</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Serial/16697173.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Serial/16697173.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02039cas a2200505 a 4500</leader>
   <controlfield tag="001">16697173</controlfield>
   <controlfield tag="005">20141025155915.0</controlfield>
@@ -172,4 +172,4 @@
     <subfield code="a">cf18 2011-05-09 to cf21</subfield>
     <subfield code="g">cf21 2011-05-26 to Ser.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16697173</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/StillImage/16891726.marcxml
+++ b/spec/fixtures/loc/m2b-classes/StillImage/16891726.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02250cam a22003854a 4500</leader>
   <controlfield tag="001">16891726</controlfield>
   <controlfield tag="005">20130607094845.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="n">I-20043453</subfield>
     <subfield code="s">93000177</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16891726</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Summary/17001357.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Summary/17001357.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00935cam a22002774a 4500</leader>
   <controlfield tag="001">17001357</controlfield>
   <controlfield tag="005">20120402162911.0</controlfield>
@@ -78,4 +78,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">ODE-ca</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17001357</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Temporal/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Temporal/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Text/16484626.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Text/16484626.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01659cam a2200361 a 4500</leader>
   <controlfield tag="001">16484626</controlfield>
   <controlfield tag="005">20110819150237.0</controlfield>
@@ -110,4 +110,4 @@
     <subfield code="z">United States</subfield>
     <subfield code="v">Juvenile literature.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16484626</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/ThreeDimensionalObject/14321148.marcxml
+++ b/spec/fixtures/loc/m2b-classes/ThreeDimensionalObject/14321148.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01646crm a22003135a 4500</leader>
   <controlfield tag="001">14321148</controlfield>
   <controlfield tag="005">20100729142741.0</controlfield>
@@ -93,4 +93,4 @@
     <subfield code="3">Contributor biographical information</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1011/2006366179-b.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14321148</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/ThreeDimensionalObject/16574557.marcxml
+++ b/spec/fixtures/loc/m2b-classes/ThreeDimensionalObject/16574557.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03022cam a2200481 i 4500</leader>
   <controlfield tag="001">16574557</controlfield>
   <controlfield tag="005">20110725131618.0</controlfield>
@@ -150,4 +150,4 @@
     <subfield code="3">Cover image</subfield>
     <subfield code="u">http://catalogimages.wiley.com/images/db/jimages/9780470527641.jpg</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16574557</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Title/11707268.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Title/11707268.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02449cgm a22003735a 4500</leader>
   <controlfield tag="001">11707268</controlfield>
   <controlfield tag="005">20130325073350.0</controlfield>
@@ -109,4 +109,4 @@
     <subfield code="h">VAD 6713 (viewing copy)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11707268</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Topic/16514537.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Topic/16514537.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01718cam a22003617i 4500</leader>
   <controlfield tag="001">16514537</controlfield>
   <controlfield tag="005">20150520153720.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="a">Israel.</subfield>
     <subfield code="b">Merkaz ha-hasbarah.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16514537</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-classes/Work/17082740.marcxml
+++ b/spec/fixtures/loc/m2b-classes/Work/17082740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01863cam a2200385 a 4500</leader>
   <controlfield tag="001">17082740</controlfield>
   <controlfield tag="005">20120215113723.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1205/2011276039-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17082740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/abbreviatedTitle/17467062.marcxml
+++ b/spec/fixtures/loc/m2b-properties/abbreviatedTitle/17467062.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01435cas a22004217a 4500</leader>
   <controlfield tag="001">17467062</controlfield>
   <controlfield tag="005">20121024070343.0</controlfield>
@@ -116,4 +116,4 @@
   <datafield tag="955" ind1=" " ind2=" ">
     <subfield code="k">xf02 2012-09-18</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17467062</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/absorbed/11318171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/absorbed/11318171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02099cas a2200481 a 4500</leader>
   <controlfield tag="001">11318171</controlfield>
   <controlfield tag="005">20100314144151.0</controlfield>
@@ -159,4 +159,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11318171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/absorbed/11318171.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/absorbed/11318171.rdfxml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11318171">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain = "Criss-cross", street-address directory, metropolitan Montreal."Criss-cross", l'annuaire rue-adresse, Montréal métropolitain "Criss-cross", street-address directory, metropolitan Montreal</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11318171title5"/>
+      <bf:workTitle rdf:resource="http://example.org/11318171title6"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>0708-7152</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/fre"/>
+      <bf:subject rdf:resource="http://example.org/11318171topic10"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-cn-qu"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/F1054.5.M83"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/F5449%20M6"/>
+      <bf:classification rdf:resource="http://example.org/11318171classification14"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>0708-7152</bf:identifierValue>
+            <bf:identifierAssigner>4</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:continues rdf:resource="http://example.org/11318171work16"/>
+      <bf:absorbed rdf:resource="http://example.org/11318171work17"/>
+      <bf:continuedBy rdf:resource="http://example.org/11318171work18"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">crisscrosslannuairerueadressemontréalmétropolitaincrisscrossstreetaddressdirectorymetropolitanmontrealengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11318171work16">
+      <bf:title>"Criss-cross", street address directory, Metropolitan Montreal</bf:title>
+      <bf:authorizedAccessPoint>"Criss-cross", street address directory, Metropolitan Montreal</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0317-686X"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/2441787"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11318171work17">
+      <bf:title>"Criss-cross" suburban Montreal street-address directory</bf:title>
+      <bf:authorizedAccessPoint>"Criss-cross" suburban Montreal street-address directory</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0703-4652"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/3979791"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11318171work18">
+      <bf:title>"Criss-cross" Montréal métropolitain</bf:title>
+      <bf:authorizedAccessPoint>"Criss-cross" Montréal métropolitain</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1187-2608"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/93641256"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/25423761"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11318171instance21">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11318171title24"/>
+      <bf:keyTitle rdf:resource="http://example.org/11318171title25"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11318171title26"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11318171title27"/>
+      <bf:titleVariation rdf:resource="http://example.org/11318171title28"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>J. Lovell</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Montreal </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1977-1990</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. ;</bf:extent>
+      <bf:dimensions>30 cm.</bf:dimensions>
+      <bf:titleStatement>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain = "Criss-cross", street-address directory, metropolitan Montreal.</bf:titleStatement>
+      <bf:providerStatement>Montreal : J. Lovell, 1977-1990.</bf:providerStatement>
+      <bf:frequencyNote>Annual</bf:frequencyNote>
+      <bf:languageNote>Text in English and French.</bf:languageNote>
+      <bf:note>Published: Lovell Litho &amp; Publications, 198-?-1990.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>86649486</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+            <bf:identifierValue>ce 79031611</bf:identifierValue>
+            <bf:identifierStatus>canceled/invalid</bf:identifierStatus>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>790316110E</bf:identifierValue>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>0708-7152</bf:identifierValue>
+            <bf:identifierAssigner>4</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/05528235"/>
+      <bf:serialFirstIssue>1977</bf:serialFirstIssue>
+      <bf:serialLastIssue>1989/90.</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11318171"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11318171annotation20">
+      <bf:derivedFrom rdf:resource="http://example.org/11318171.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/caoonl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/caoonl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/caoonl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/b2q"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nlc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/isds/c"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2010-03-14T14:41</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11318171"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11318171helditem47">
+      <bf:label>F1054.5.M83 C74</bf:label>
+      <bf:shelfMarkLcc>F1054.5.M83 C74</bf:shelfMarkLcc>
+      <bf:shelfMarkLcc>F5449 M6 A27214 fol.</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11318171instance21"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11318171title5">
+      <bf:label>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain = "Criss-cross", street-address directory, metropolitan Montreal.</bf:label>
+      <bf:titleValue>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain </bf:titleValue>
+      <bf:subtitle>"Criss-cross", street-address directory, metropolitan Montreal.</bf:subtitle>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11318171title6">
+      <bf:titleValue>"Criss-cross", street-address directory, metropolitan Montreal.</bf:titleValue>
+      <bf:titleType>parallel</bf:titleType>
+   </bf:Title>
+   <bf:Topic rdf:about="http://example.org/11318171topic10">
+      <bf:authorizedAccessPoint>Rues--Québec (Province)--Montréal, Région de--Répertoires</bf:authorizedAccessPoint>
+      <bf:label>Rues--Québec (Province)--Montréal, Région de--Répertoires</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Rues--Québec (Province)--Montréal, Région de--Répertoires</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Rues</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Rues</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Québec (Province)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Québec (Province)</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Montréal, Région de</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Montréal, Région de</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Répertoires</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Répertoires.</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11318171classification14">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>971.4/28104/025</bf:classificationNumber>
+      <bf:label>971.4/28104/025</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>19</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/11318171title24">
+      <bf:label>"Criss-cross", annu. rue-adresse, Montr. métrop. (1977)</bf:label>
+      <bf:titleQualifier>(1977)</bf:titleQualifier>
+      <bf:titleValue>"Criss-cross", annu. rue-adresse, Montr. métrop.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11318171title25">
+      <bf:label>"Criss-cross". L'annuaire rue-adresse. Montréal métropolitain (1977)</bf:label>
+      <bf:titleQualifier>(1977)</bf:titleQualifier>
+      <bf:titleValue>"Criss-cross". L'annuaire rue-adresse. Montréal métropolitain</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11318171title26">
+      <bf:label>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain = "Criss-cross", street-address directory, metropolitan Montreal.</bf:label>
+      <bf:titleValue>"Criss-cross", l'annuaire rue-adresse, Montréal métropolitain </bf:titleValue>
+      <bf:subtitle>"Criss-cross", street-address directory, metropolitan Montreal.</bf:subtitle>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11318171title27">
+      <bf:titleValue>"Criss-cross", street-address directory, metropolitan Montreal.</bf:titleValue>
+      <bf:titleType>parallel</bf:titleType>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11318171title28">
+      <bf:titleType>parallel</bf:titleType>
+      <bf:label>"Criss-cross", street-address directory, metropolitan Montreal</bf:label>
+      <bf:titleValue>"Criss-cross", street-address directory, metropolitan Montreal</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/absorbed/11318171.ttl
+++ b/spec/fixtures/loc/m2b-properties/absorbed/11318171.ttl
@@ -1,0 +1,211 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11318171annotation20> a bf:Annotation;
+   bf:annotates <http://example.org/11318171>;
+   bf:changeDate "2010-03-14T14:41";
+   bf:derivedFrom <http://example.org/11318171.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/nlc>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/isds/c>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/caoonl>,
+     <http://id.loc.gov/vocabulary/organizations/b2q>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/caoonl>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11318171helditem47> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11318171instance21>;
+   bf:label "F1054.5.M83 C74";
+   bf:shelfMarkLcc "F1054.5.M83 C74",
+     "F5449 M6 A27214 fol." .
+
+<http://example.org/11318171classification14> a bf:Classification;
+   bf:classificationEdition "full",
+     "19";
+   bf:classificationNumber "971.4/28104/025";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "971.4/28104/025" .
+
+<http://example.org/11318171instance21> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11318171title24>;
+   bf:dimensions "30 cm.";
+   bf:extent "v. ;";
+   bf:frequencyNote "Annual";
+   bf:instanceOf <http://example.org/11318171>;
+   bf:instanceTitle <http://example.org/11318171title26>,
+     <http://example.org/11318171title27>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "4";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "0708-7152"
+   ];
+   bf:keyTitle <http://example.org/11318171title25>;
+   bf:languageNote "Text in English and French.";
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "86649486"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierStatus "canceled/invalid";
+     bf:identifierValue "ce 79031611"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:nban [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "790316110E"
+   ];
+   bf:note "Published: Lovell Litho & Publications, 198-?-1990.",
+     "SERBIB/SERLOC merged record";
+   bf:providerStatement "Montreal : J. Lovell, 1977-1990.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1977-1990";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "J. Lovell"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Montreal "
+     ]
+   ];
+   bf:serialFirstIssue "1977";
+   bf:serialLastIssue "1989/90.";
+   bf:systemNumber <http://www.worldcat.org/oclc/05528235>;
+   bf:titleStatement "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain = \"Criss-cross\", street-address directory, metropolitan Montreal.";
+   bf:titleVariation <http://example.org/11318171title28> .
+
+<http://example.org/11318171title24> a bf:Title;
+   bf:label "\"Criss-cross\", annu. rue-adresse, Montr. métrop. (1977)";
+   bf:titleQualifier "(1977)";
+   bf:titleValue "\"Criss-cross\", annu. rue-adresse, Montr. métrop." .
+
+<http://example.org/11318171title25> a bf:Title;
+   bf:label "\"Criss-cross\". L'annuaire rue-adresse. Montréal métropolitain (1977)";
+   bf:titleQualifier "(1977)";
+   bf:titleValue "\"Criss-cross\". L'annuaire rue-adresse. Montréal métropolitain" .
+
+<http://example.org/11318171title26> a bf:Title;
+   bf:label "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain = \"Criss-cross\", street-address directory, metropolitan Montreal.";
+   bf:subtitle "\"Criss-cross\", street-address directory, metropolitan Montreal.";
+   bf:titleValue "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain " .
+
+<http://example.org/11318171title27> a bf:Title;
+   bf:titleType "parallel";
+   bf:titleValue "\"Criss-cross\", street-address directory, metropolitan Montreal." .
+
+<http://example.org/11318171title28> a bf:Title;
+   bf:label "\"Criss-cross\", street-address directory, metropolitan Montreal";
+   bf:titleType "parallel";
+   bf:titleValue "\"Criss-cross\", street-address directory, metropolitan Montreal" .
+
+<http://example.org/11318171title5> a bf:Title;
+   bf:label "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain = \"Criss-cross\", street-address directory, metropolitan Montreal.";
+   bf:subtitle "\"Criss-cross\", street-address directory, metropolitan Montreal.";
+   bf:titleValue "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain " .
+
+<http://example.org/11318171title6> a bf:Title;
+   bf:titleType "parallel";
+   bf:titleValue "\"Criss-cross\", street-address directory, metropolitan Montreal." .
+
+<http://example.org/11318171topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Rues--Québec (Province)--Montréal, Région de--Répertoires";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Rues--Québec (Province)--Montréal, Région de--Répertoires";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Rues";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Rues"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Québec (Province)";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Québec (Province)"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Montréal, Région de";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Montréal, Région de"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Répertoires";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Répertoires."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Rues--Québec (Province)--Montréal, Région de--Répertoires" .
+
+<http://example.org/11318171work16> a bf:Work;
+   bf:authorizedAccessPoint "\"Criss-cross\", street address directory, Metropolitan Montreal";
+   bf:issn <urn:issn:0317-686X>;
+   bf:systemNumber <http://www.worldcat.org/oclc/2441787>;
+   bf:title "\"Criss-cross\", street address directory, Metropolitan Montreal" .
+
+<http://example.org/11318171work17> a bf:Work;
+   bf:authorizedAccessPoint "\"Criss-cross\" suburban Montreal street-address directory";
+   bf:issn <urn:issn:0703-4652>;
+   bf:systemNumber <http://www.worldcat.org/oclc/3979791>;
+   bf:title "\"Criss-cross\" suburban Montreal street-address directory" .
+
+<http://example.org/11318171work18> a bf:Work;
+   bf:authorizedAccessPoint "\"Criss-cross\" Montréal métropolitain";
+   bf:issn <urn:issn:1187-2608>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/93641256>;
+   bf:systemNumber <http://www.worldcat.org/oclc/25423761>;
+   bf:title "\"Criss-cross\" Montréal métropolitain" .
+
+<http://example.org/11318171> a bf:Work,
+     bf:Text;
+   bf:absorbed <http://example.org/11318171work17>;
+   bf:authorizedAccessPoint "\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain = \"Criss-cross\", street-address directory, metropolitan Montreal.\"Criss-cross\", l'annuaire rue-adresse, Montréal métropolitain \"Criss-cross\", street-address directory, metropolitan Montreal",
+     "crisscrosslannuairerueadressemontréalmétropolitaincrisscrossstreetaddressdirectorymetropolitanmontrealengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11318171classification14>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/F1054.5.M83>,
+     <http://id.loc.gov/authorities/classification/F5449%20M6>;
+   bf:continuedBy <http://example.org/11318171work18>;
+   bf:continues <http://example.org/11318171work16>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0708-7152"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "4";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0708-7152"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>,
+     <http://id.loc.gov/vocabulary/languages/fre>;
+   bf:subject <http://example.org/11318171topic10>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-cn-qu>;
+   bf:workTitle <http://example.org/11318171title5>,
+     <http://example.org/11318171title6> .

--- a/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.marcxml
+++ b/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01830cas a2200481 a 4500</leader>
   <controlfield tag="001">11346685</controlfield>
   <controlfield tag="005">20130303163042.0</controlfield>
@@ -163,4 +163,4 @@
     <subfield code="b">MUS</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11346685</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.rdfxml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11346685">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Home &amp; studio recording.Home &amp; studio recording</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11346685title5"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11346685topic8"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/TK7881.4"/>
+      <bf:classification rdf:resource="http://example.org/11346685classification10"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:absorbed rdf:resource="http://example.org/11346685work12"/>
+      <bf:continuedBy rdf:resource="http://example.org/11346685work13"/>
+      <bf:otherEdition rdf:resource="http://example.org/11346685work14"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">homestudiorecordingengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work12">
+      <bf:title>Music technology</bf:title>
+      <bf:authorizedAccessPoint>Music technology</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0896-2480"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn87033459"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/16461726"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work13">
+      <bf:title>Recording</bf:title>
+      <bf:authorizedAccessPoint>Recording</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1078-8352"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/94642153"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/31020245"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work14">
+      <bf:title>Home &amp; studio recording (Spanish ed.)</bf:title>
+      <bf:authorizedAccessPoint>Home &amp; studio recording (Spanish ed.)</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1074-2050"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn94000149"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11346685instance17">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11346685title20"/>
+      <bf:keyTitle rdf:resource="http://example.org/11346685title21"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11346685title22"/>
+      <bf:titleVariation rdf:resource="http://example.org/11346685title23"/>
+      <bf:titleVariation rdf:resource="http://example.org/11346685title24"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Music Maker Publications</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Canoga Park, CA </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>-c1994</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. (some col.) ;</bf:illustrationNote>
+      <bf:titleStatement>Home &amp; studio recording.</bf:titleStatement>
+      <bf:providerStatement>Canoga Park, CA : Music Maker Publications, -c1994.</bf:providerStatement>
+      <bf:frequencyNote>Monthly</bf:frequencyNote>
+      <bf:note>Issues for &lt;June 1988-&gt; published: Chatsworth, CA.</bf:note>
+      <bf:note>Also issued in Spanish.</bf:note>
+      <bf:note>Description based on: Vol. 3, no. 8 (June 1990); title from cover.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>88651318</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+            <bf:identifierValue>sn 87007375</bf:identifierValue>
+            <bf:identifierStatus>canceled/invalid</bf:identifierStatus>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:postalRegistration>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/postalRegistration"/>
+            <bf:identifierValue>002298</bf:identifierValue>
+            <bf:identifierAssigner>USPS</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:postalRegistration>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/17285024"/>
+      <bf:stockNumber>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/stockNumber"/>
+            <bf:identifierAssigner>Music Maker Publications, Inc., 21601 Devonshire St., Suite 212, Chatsworth, CA 91311</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:stockNumber>
+      <bf:serialLastIssue>v. 7, no. 9 (June 1994).</bf:serialLastIssue>
+      <bf:serialFirstIssue>Began in 1987.</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11346685"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11346685annotation16">
+      <bf:derivedFrom rdf:resource="http://example.org/11346685.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/clu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nic"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mwwf"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-03-03T16:30</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11346685"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11346685helditem46">
+      <bf:label>TK7881.4 .H65</bf:label>
+      <bf:shelfMarkLcc>TK7881.4 .H65</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11346685instance17"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11346685title5">
+      <bf:label>Home &amp; studio recording.</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Topic rdf:about="http://example.org/11346685topic8">
+      <bf:authorizedAccessPoint>Sound--Recording and reproducing--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Sound--Recording and reproducing--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Sound--Recording and reproducing--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Sound</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Sound</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Recording and reproducing</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Recording and reproducing</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11346685classification10">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>621.389/3</bf:classificationNumber>
+      <bf:label>621.389/3</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>19</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/11346685title20">
+      <bf:label>Home stud. rec.</bf:label>
+      <bf:titleValue>Home stud. rec.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title21">
+      <bf:label>Home &amp; studio recording</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title22">
+      <bf:label>Home &amp; studio recording.</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title23">
+      <bf:titleType>portion</bf:titleType>
+      <bf:label>Home and studio recording</bf:label>
+      <bf:titleValue>Home and studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title24">
+      <bf:titleType>running</bf:titleType>
+      <bf:label>H &amp; SR</bf:label>
+      <bf:titleValue>H &amp; SR</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.ttl
+++ b/spec/fixtures/loc/m2b-properties/absorbedBy/11346685.ttl
@@ -1,0 +1,201 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11346685annotation16> a bf:Annotation;
+   bf:annotates <http://example.org/11346685>;
+   bf:changeDate "2013-03-03T16:30";
+   bf:derivedFrom <http://example.org/11346685.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nsdp>,
+     <http://id.loc.gov/vocabulary/organizations/clu>,
+     <http://id.loc.gov/vocabulary/organizations/nic>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/mwwf>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/nsdp>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11346685helditem46> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11346685instance17>;
+   bf:label "TK7881.4 .H65";
+   bf:shelfMarkLcc "TK7881.4 .H65" .
+
+<http://example.org/11346685classification10> a bf:Classification;
+   bf:classificationEdition "full",
+     "19";
+   bf:classificationNumber "621.389/3";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "621.389/3" .
+
+<http://example.org/11346685instance17> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11346685title20>;
+   bf:dimensions "28 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Monthly";
+   bf:illustrationNote "ill. (some col.) ;";
+   bf:instanceOf <http://example.org/11346685>;
+   bf:instanceTitle <http://example.org/11346685title22>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "0896-7172"
+   ];
+   bf:keyTitle <http://example.org/11346685title21>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "88651318"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierStatus "canceled/invalid";
+     bf:identifierValue "sn 87007375"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Issues for <June 1988-> published: Chatsworth, CA.",
+     "Also issued in Spanish.",
+     "Description based on: Vol. 3, no. 8 (June 1990); title from cover.",
+     "SERBIB/SERLOC merged record";
+   bf:postalRegistration [
+     a bf:Identifier;
+     bf:identifierAssigner "USPS";
+     bf:identifierScheme loc_ids:postalRegistration;
+     bf:identifierValue "002298"
+   ];
+   bf:providerStatement "Canoga Park, CA : Music Maker Publications, -c1994.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "-c1994";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Music Maker Publications"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Canoga Park, CA "
+     ]
+   ];
+   bf:serialFirstIssue "Began in 1987.";
+   bf:serialLastIssue "v. 7, no. 9 (June 1994).";
+   bf:stockNumber [
+     a bf:Identifier;
+     bf:identifierAssigner "Music Maker Publications, Inc., 21601 Devonshire St., Suite 212, Chatsworth, CA 91311";
+     bf:identifierScheme loc_ids:stockNumber
+   ];
+   bf:systemNumber <http://www.worldcat.org/oclc/17285024>;
+   bf:titleStatement "Home & studio recording.";
+   bf:titleVariation <http://example.org/11346685title23>,
+     <http://example.org/11346685title24> .
+
+<http://example.org/11346685title20> a bf:Title;
+   bf:label "Home stud. rec.";
+   bf:titleValue "Home stud. rec." .
+
+<http://example.org/11346685title21> a bf:Title;
+   bf:label "Home & studio recording";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685title22> a bf:Title;
+   bf:label "Home & studio recording.";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685title23> a bf:Title;
+   bf:label "Home and studio recording";
+   bf:titleType "portion";
+   bf:titleValue "Home and studio recording" .
+
+<http://example.org/11346685title24> a bf:Title;
+   bf:label "H & SR";
+   bf:titleType "running";
+   bf:titleValue "H & SR" .
+
+<http://example.org/11346685title5> a bf:Title;
+   bf:label "Home & studio recording.";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685topic8> a bf:Topic;
+   bf:authorizedAccessPoint "Sound--Recording and reproducing--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Sound--Recording and reproducing--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Sound";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Sound"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Recording and reproducing";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Recording and reproducing"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Sound--Recording and reproducing--Periodicals" .
+
+<http://example.org/11346685work12> a bf:Work;
+   bf:authorizedAccessPoint "Music technology";
+   bf:issn <urn:issn:0896-2480>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn87033459>;
+   bf:systemNumber <http://www.worldcat.org/oclc/16461726>;
+   bf:title "Music technology" .
+
+<http://example.org/11346685work13> a bf:Work;
+   bf:authorizedAccessPoint "Recording";
+   bf:issn <urn:issn:1078-8352>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/94642153>;
+   bf:systemNumber <http://www.worldcat.org/oclc/31020245>;
+   bf:title "Recording" .
+
+<http://example.org/11346685work14> a bf:Work;
+   bf:authorizedAccessPoint "Home & studio recording (Spanish ed.)";
+   bf:issn <urn:issn:1074-2050>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn94000149>;
+   bf:title "Home & studio recording (Spanish ed.)" .
+
+<http://example.org/11346685> a bf:Work,
+     bf:Text;
+   bf:absorbed <http://example.org/11346685work12>;
+   bf:authorizedAccessPoint "Home & studio recording.Home & studio recording",
+     "homestudiorecordingengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11346685classification10>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/TK7881.4>;
+   bf:continuedBy <http://example.org/11346685work13>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0896-7172"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0896-7172"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:otherEdition <http://example.org/11346685work14>;
+   bf:subject <http://example.org/11346685topic8>;
+   bf:workTitle <http://example.org/11346685title5> .

--- a/spec/fixtures/loc/m2b-properties/accessCondition/16562286.marcxml
+++ b/spec/fixtures/loc/m2b-properties/accessCondition/16562286.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01623ckd a22003977a 4500</leader>
   <controlfield tag="001">16562286</controlfield>
   <controlfield tag="005">20110919121809.0</controlfield>
@@ -114,4 +114,4 @@
     <subfield code="m">(B size)</subfield>
     <subfield code="o">ppsd</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16562286</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/agent/11187857.marcxml
+++ b/spec/fixtures/loc/m2b-properties/agent/11187857.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02911cas a2200685 a 4500</leader>
   <controlfield tag="001">11187857</controlfield>
   <controlfield tag="005">20140912075312.0</controlfield>
@@ -238,4 +238,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11187857</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/annotates/15599751.marcxml
+++ b/spec/fixtures/loc/m2b-properties/annotates/15599751.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01787cam a22004217a 4500</leader>
   <controlfield tag="001">15599751</controlfield>
   <controlfield tag="005">20120719124759.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="i">.R67 2009</subfield>
     <subfield code="t">Copy 1</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15599751</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/annotationAssertedBy/15599751.marcxml
+++ b/spec/fixtures/loc/m2b-properties/annotationAssertedBy/15599751.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01787cam a22004217a 4500</leader>
   <controlfield tag="001">15599751</controlfield>
   <controlfield tag="005">20120719124759.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="i">.R67 2009</subfield>
     <subfield code="t">Copy 1</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15599751</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/annotationBody/15599751.marcxml
+++ b/spec/fixtures/loc/m2b-properties/annotationBody/15599751.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01787cam a22004217a 4500</leader>
   <controlfield tag="001">15599751</controlfield>
   <controlfield tag="005">20120719124759.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="i">.R67 2009</subfield>
     <subfield code="t">Copy 1</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15599751</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/arrangement/12700618.marcxml
+++ b/spec/fixtures/loc/m2b-properties/arrangement/12700618.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02231cac a22003617a 4500</leader>
   <controlfield tag="001">12700618</controlfield>
   <controlfield tag="005">20070825121901.0</controlfield>
@@ -105,4 +105,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12700618</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/aspectRatio/16501167.marcxml
+++ b/spec/fixtures/loc/m2b-properties/aspectRatio/16501167.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00706cgm a22002053a 4500</leader>
   <controlfield tag="001">16501167</controlfield>
   <controlfield tag="005">20120117130630.0</controlfield>
@@ -53,4 +53,4 @@
     <subfield code="a">Copyright Collection (Library of Congress)</subfield>
     <subfield code="5">DLC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16501167</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/assertionDate/15747233.marcxml
+++ b/spec/fixtures/loc/m2b-properties/assertionDate/15747233.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03116cam a2200493 a 4500</leader>
   <controlfield tag="001">15747233</controlfield>
   <controlfield tag="005">20140822162057.0</controlfield>
@@ -225,4 +225,4 @@
   <datafield tag="830" ind1=" " ind2="0">
     <subfield code="a">Classical texts.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15747233</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/audience/15628464.marcxml
+++ b/spec/fixtures/loc/m2b-properties/audience/15628464.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02363cam a22004214a 4500</leader>
   <controlfield tag="001">15628464</controlfield>
   <controlfield tag="005">20101124161102.0</controlfield>
@@ -138,4 +138,4 @@
     <subfield code="d">1929-</subfield>
     <subfield code="t">Physics science projects using the scientific method.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15628464</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/audienceAssigner/15628464.marcxml
+++ b/spec/fixtures/loc/m2b-properties/audienceAssigner/15628464.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02363cam a22004214a 4500</leader>
   <controlfield tag="001">15628464</controlfield>
   <controlfield tag="005">20101124161102.0</controlfield>
@@ -138,4 +138,4 @@
     <subfield code="d">1929-</subfield>
     <subfield code="t">Physics science projects using the scientific method.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15628464</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/authorizedAccessPoint/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/authorizedAccessPoint/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/awardNote/14979049.marcxml
+++ b/spec/fixtures/loc/m2b-properties/awardNote/14979049.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01705cam a2200409 a 4500</leader>
   <controlfield tag="001">14979049</controlfield>
   <controlfield tag="005">20121206163859.0</controlfield>
@@ -126,4 +126,4 @@
   <datafield tag="650" ind1=" " ind2="1">
     <subfield code="a">Short stories.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14979049</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/barcode/12096399.marcxml
+++ b/spec/fixtures/loc/m2b-properties/barcode/12096399.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01740cam a2200433 a 4500</leader>
   <controlfield tag="001">12096399</controlfield>
   <controlfield tag="005">20090313124643.0</controlfield>
@@ -132,4 +132,4 @@
     <subfield code="i">.S64 no.68</subfield>
     <subfield code="p">31142026198104</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12096399</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/carrierCategory/2466523.marcxml
+++ b/spec/fixtures/loc/m2b-properties/carrierCategory/2466523.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01458nam a2200349 a 4500</leader>
   <controlfield tag="001">2466523</controlfield>
   <controlfield tag="005">19900921105732.7</controlfield>
@@ -98,4 +98,4 @@
     <subfield code="m">So Asia</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=2466523</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/carrierCategory/5696410.marcxml
+++ b/spec/fixtures/loc/m2b-properties/carrierCategory/5696410.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01779cim a2200373 a 4500</leader>
   <controlfield tag="001">5696410</controlfield>
   <controlfield tag="005">20060223115046.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="h">LWO 2725 (preservation master)</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5696410</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicAscensionAndDeclination/12166066.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicAscensionAndDeclination/12166066.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01439cem a2200337 a 4500</leader>
   <controlfield tag="001">12166066</controlfield>
   <controlfield tag="005">20000908072612.0</controlfield>
@@ -91,4 +91,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">George Philip &amp; Son.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12166066</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicCoordinates/12027022.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicCoordinates/12027022.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00830cem a2200241 a 4500</leader>
   <controlfield tag="001">12027022</controlfield>
   <controlfield tag="005">20000602072602.0</controlfield>
@@ -66,4 +66,4 @@
   <datafield tag="650" ind1=" " ind2="0">
     <subfield code="a">World maps.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12027022</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicEquinox/12166066.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicEquinox/12166066.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01439cem a2200337 a 4500</leader>
   <controlfield tag="001">12166066</controlfield>
   <controlfield tag="005">20000908072612.0</controlfield>
@@ -91,4 +91,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">George Philip &amp; Son.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12166066</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicExclusionGRing/13012673.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicExclusionGRing/13012673.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01181cem a2200289 a 4500</leader>
   <controlfield tag="001">13012673</controlfield>
   <controlfield tag="005">20030107101058.0</controlfield>
@@ -87,4 +87,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">National Cartography and Geospatial Center (U.S.)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13012673</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicOuterGRing/13012673.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicOuterGRing/13012673.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01181cem a2200289 a 4500</leader>
   <controlfield tag="001">13012673</controlfield>
   <controlfield tag="005">20030107101058.0</controlfield>
@@ -87,4 +87,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">National Cartography and Geospatial Center (U.S.)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13012673</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicProjection/12027022.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicProjection/12027022.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00830cem a2200241 a 4500</leader>
   <controlfield tag="001">12027022</controlfield>
   <controlfield tag="005">20000602072602.0</controlfield>
@@ -66,4 +66,4 @@
   <datafield tag="650" ind1=" " ind2="0">
     <subfield code="a">World maps.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12027022</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/cartographicScale/12166066.marcxml
+++ b/spec/fixtures/loc/m2b-properties/cartographicScale/12166066.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01439cem a2200337 a 4500</leader>
   <controlfield tag="001">12166066</controlfield>
   <controlfield tag="005">20000908072612.0</controlfield>
@@ -91,4 +91,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">George Philip &amp; Son.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12166066</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/changeDate/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/changeDate/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classification/1683575.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classification/1683575.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01300nam a22003257a 4500</leader>
   <controlfield tag="001">1683575</controlfield>
   <controlfield tag="005">19990715053326.6</controlfield>
@@ -94,4 +94,4 @@
     <subfield code="m">So Asia</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=1683575</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationAssigner/13694403.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationAssigner/13694403.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01454cam a22003854a 4500</leader>
   <controlfield tag="001">13694403</controlfield>
   <controlfield tag="005">20070824234633.0</controlfield>
@@ -130,4 +130,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13694403</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationAssigner/16697173.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationAssigner/16697173.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02039cas a2200505 a 4500</leader>
   <controlfield tag="001">16697173</controlfield>
   <controlfield tag="005">20141025155915.0</controlfield>
@@ -172,4 +172,4 @@
     <subfield code="a">cf18 2011-05-09 to cf21</subfield>
     <subfield code="g">cf21 2011-05-26 to Ser.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16697173</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationAssigner/16845697.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationAssigner/16845697.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00530cas a22001814a 4500</leader>
   <controlfield tag="001">16845697</controlfield>
   <controlfield tag="005">20110816110341.0</controlfield>
@@ -45,4 +45,4 @@
   <datafield tag="984" ind1=" " ind2=" ">
     <subfield code="b">Record input for RHIP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16845697</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationAssigner/4434648.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationAssigner/4434648.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01079pam a2200301 a 4500</leader>
   <controlfield tag="001">4434648</controlfield>
   <controlfield tag="005">19950213100643.0</controlfield>
@@ -88,4 +88,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4434648</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationAssigner/9660894.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationAssigner/9660894.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01192cam a22002771  4500</leader>
   <controlfield tag="001">9660894</controlfield>
   <controlfield tag="005">20050513203552.0</controlfield>
@@ -80,4 +80,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=9660894</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationDdc/4595939.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationDdc/4595939.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01055cam a2200277 i 4500</leader>
   <controlfield tag="001">4595939</controlfield>
   <controlfield tag="005">19981029161712.1</controlfield>
@@ -80,4 +80,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4595939</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationEdition/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationEdition/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationLcc/12993812.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationLcc/12993812.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01240cem a2200313 a 4500</leader>
   <controlfield tag="001">12993812</controlfield>
   <controlfield tag="005">20080702145225.0</controlfield>
@@ -90,4 +90,4 @@
     <subfield code="a">Okayama-ken (Japan).</subfield>
     <subfield code="b">No&#x304;son Shinko&#x304;ka.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12993812</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationLcc/5833012.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationLcc/5833012.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01995cem a2200397 a 4500</leader>
   <controlfield tag="001">5833012</controlfield>
   <controlfield tag="005">20090929114443.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5833012</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationNlm/1007064.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationNlm/1007064.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00881pam a2200277 a 4500</leader>
   <controlfield tag="001">1007064</controlfield>
   <controlfield tag="005">19880701143120.5</controlfield>
@@ -81,4 +81,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=1007064</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationNumber/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationNumber/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationScheme/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationScheme/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationScheme/4609487.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationScheme/4609487.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01246cam a2200301 i 4500</leader>
   <controlfield tag="001">4609487</controlfield>
   <controlfield tag="005">20150415112302.0</controlfield>
@@ -85,4 +85,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4609487</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationStatus/5006515.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationStatus/5006515.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02525cmm a22004697a 4500</leader>
   <controlfield tag="001">5006515</controlfield>
   <controlfield tag="005">20090403074020.0</controlfield>
@@ -133,4 +133,4 @@
     <subfield code="b">Bureau of the Census.</subfield>
     <subfield code="b">Data User Services Division.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5006515</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationTable/15535030.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationTable/15535030.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02295cam a22004217a 4500</leader>
   <controlfield tag="001">15535030</controlfield>
   <controlfield tag="005">20120329103747.0</controlfield>
@@ -169,4 +169,4 @@
     <subfield code="a">Reser series</subfield>
     <subfield code="x">0123-4567</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15535030</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationTableSeq/15535030.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationTableSeq/15535030.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02295cam a22004217a 4500</leader>
   <controlfield tag="001">15535030</controlfield>
   <controlfield tag="005">20120329103747.0</controlfield>
@@ -169,4 +169,4 @@
     <subfield code="a">Reser series</subfield>
     <subfield code="x">0123-4567</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15535030</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/classificationUdc/2610901.marcxml
+++ b/spec/fixtures/loc/m2b-properties/classificationUdc/2610901.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00922cam a2200289 a 4500</leader>
   <controlfield tag="001">2610901</controlfield>
   <controlfield tag="005">20040227074710.0</controlfield>
@@ -81,4 +81,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=2610901</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/coden/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/coden/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/colorContent/16501167.marcxml
+++ b/spec/fixtures/loc/m2b-properties/colorContent/16501167.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00706cgm a22002053a 4500</leader>
   <controlfield tag="001">16501167</controlfield>
   <controlfield tag="005">20120117130630.0</controlfield>
@@ -53,4 +53,4 @@
     <subfield code="a">Copyright Collection (Library of Congress)</subfield>
     <subfield code="5">DLC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16501167</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/contentCategory/13623634.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentCategory/13623634.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01816nam a22003735a 4500</leader>
   <controlfield tag="001">13623634</controlfield>
   <controlfield tag="005">20040615071530.0</controlfield>
@@ -105,4 +105,4 @@
     <subfield code="a">Open-file report (Utah Geological Survey) ;</subfield>
     <subfield code="v">420.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13623634</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/contentCategory/243272.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentCategory/243272.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01841cam a2200421 a 4500</leader>
   <controlfield tag="001">243272</controlfield>
   <controlfield tag="005">20130408112256.0</controlfield>

--- a/spec/fixtures/loc/m2b-properties/contentCategory/5808761.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentCategory/5808761.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01619cpcaa2200361   4500</leader>
   <controlfield tag="001">5808761</controlfield>
   <controlfield tag="005">20120329155857.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">MSS.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5808761</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/contentCategory/5810233.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentCategory/5810233.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01257cpcaa2200289   4500</leader>
   <controlfield tag="001">5810233</controlfield>
   <controlfield tag="005">20130502124205.0</controlfield>
@@ -85,4 +85,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">MSS.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5810233</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/contentsNote/11785748.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentsNote/11785748.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01353cjm a2200301 a 4500</leader>
   <controlfield tag="001">11785748</controlfield>
   <controlfield tag="005">19990929152642.0</controlfield>
@@ -85,4 +85,4 @@
     <subfield code="d">1899-1974.</subfield>
     <subfield code="4">prf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11785748</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/contentsNote/8088133.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contentsNote/8088133.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00732cim a2200217u  4500</leader>
   <controlfield tag="001">8088133</controlfield>
   <controlfield tag="005">20150619054544.0</controlfield>
@@ -54,4 +54,4 @@
     <subfield code="a">Banerjee, Nikhil,</subfield>
     <subfield code="d">1931-1986.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=8088133</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/continuedBy/11338843.marcxml
+++ b/spec/fixtures/loc/m2b-properties/continuedBy/11338843.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01780cas a2200445 a 4500</leader>
   <controlfield tag="001">11338843</controlfield>
   <controlfield tag="005">20121214081036.0</controlfield>
@@ -134,4 +134,4 @@
     <subfield code="h">Microfilm 01104 no. 1544-1545 AP</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11338843</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/continuedBy/11338843.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/continuedBy/11338843.rdfxml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11338843">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>American Peace Society. Advocate of peace (1894)</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Advocate of peace (1894)</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/11338843title6"/>
+      <bf:contributor rdf:resource="http://example.org/11338843organization7"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic9"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic10"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic11"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/Z6951"/>
+      <bf:classificationDdc rdf:resource="http://dewey.info/class/051/about"/>
+      <bf:continues rdf:resource="http://example.org/11338843work14"/>
+      <bf:continuedBy rdf:resource="http://example.org/11338843work15"/>
+      <bf:reproduction rdf:resource="http://example.org/11338843work16"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">americanpeacesocietyadvocateofpeace1894engworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work14">
+      <bf:title>American advocate of peace (1893)</bf:title>
+      <bf:authorizedAccessPoint>American advocate of peace (1893)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sf88092312"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/7650660"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work15">
+      <bf:title>Advocate of peace through justice</bf:title>
+      <bf:authorizedAccessPoint>Advocate of peace through justice</bf:authorizedAccessPoint>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/12953613"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work16">
+      <bf:authorizedAccessPoint>The Advocate of peace</bf:authorizedAccessPoint>
+      <bf:title>The Advocate of peace</bf:title>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11338843instance20">
+      <bf:instanceTitle rdf:resource="http://example.org/11338843title22"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Ann Arbor, Mich. :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1975</bf:providerDate>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Xerox University Microfilms,</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+         </bf:Provider>
+      </bf:publication>
+      <bf:extent>2 microfilm reels ; 35 mm.</bf:extent>
+      <bf:carrierCategory rdf:resource="http://example.org/11338843category25"/>
+      <bf:instanceOf rdf:resource="http://example.org/11338843work16"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11338843instance19">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11338843title22"/>
+      <bf:title xml:lang="x-bf-sort">Advocate of peace</bf:title>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>American Peace Society</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Boston, Mass. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1894-1920</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11338843instance26"/>
+      <bf:extent>27 v. ;</bf:extent>
+      <bf:dimensions>24-31 cm.</bf:dimensions>
+      <bf:titleStatement>The Advocate of peace</bf:titleStatement>
+      <bf:formDesignation>microform.</bf:formDesignation>
+      <bf:providerStatement>Boston, Mass. : American Peace Society, 1894-1920.</bf:providerStatement>
+      <bf:frequencyNote>Monthly (except Sept.), Aug./Sept. 1913-Feb. 1920</bf:frequencyNote>
+      <bf:note>Film incomplete: 1907-1920 wanting.</bf:note>
+      <bf:note>Title from cover.</bf:note>
+      <bf:note>Microfilm.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sf 88091499</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/06215540"/>
+      <bf:serialFirstIssue>Vol. 56, no. 1 (Jan. 1894)</bf:serialFirstIssue>
+      <bf:serialLastIssue>v. 82, no. 2 (Feb. 1920).</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11338843"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11338843instance26">
+      <bf:title>Advocate of peace (1894)</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/6797409"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11338843annotation18">
+      <bf:derivedFrom rdf:resource="http://example.org/11338843.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/viblbv"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/pes"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2012-12-14T08:10</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11338843"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11338843helditem41">
+      <bf:label>Z6951 .A497 reel 1544-</bf:label>
+      <bf:shelfMarkLcc>Z6951 .A497 reel 1544-</bf:shelfMarkLcc>
+      <bf:shelfMarkDdc>051 A51p2</bf:shelfMarkDdc>
+      <bf:holdingFor rdf:resource="http://example.org/11338843instance19"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11338843title6">
+      <bf:titleValue>Advocate of peace (1894)</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/11338843organization7">
+      <bf:label>American Peace Society.</bf:label>
+      <bf:authorizedAccessPoint>American Peace Society.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>American Peace Society.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11338843topic9">
+      <bf:authorizedAccessPoint>International relations--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>International relations--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>International relations--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>International relations</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>International relations</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11338843topic10">
+      <bf:authorizedAccessPoint>Peace--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Peace--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Peace--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Peace</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Peace</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11338843topic11">
+      <bf:authorizedAccessPoint>Arbitration (International law)--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Arbitration (International law)--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Arbitration (International law)--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Arbitration (International law)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Arbitration (International law)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11338843title22">
+      <bf:label>The Advocate of peace</bf:label>
+   </bf:Title>
+   <bf:Category rdf:about="http://example.org/11338843category25">
+      <bf:categoryValue>Microfilm</bf:categoryValue>
+   </bf:Category>
+   <bf:Title rdf:about="http://example.org/11338843title22">
+      <bf:label>The Advocate of peace [microform].</bf:label>
+      <bf:titleValue>The Advocate of peace</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/continuedBy/11338843.ttl
+++ b/spec/fixtures/loc/m2b-properties/continuedBy/11338843.ttl
@@ -1,0 +1,216 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11338843annotation18> a bf:Annotation;
+   bf:annotates <http://example.org/11338843>;
+   bf:changeDate "2012-12-14T08:10";
+   bf:derivedFrom <http://example.org/11338843.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/pes>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/viblbv>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11338843helditem41> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11338843instance19>;
+   bf:label "Z6951 .A497 reel 1544-";
+   bf:shelfMarkDdc "051 A51p2";
+   bf:shelfMarkLcc "Z6951 .A497 reel 1544-" .
+
+<http://example.org/11338843instance20> a bf:Instance;
+   bf:carrierCategory <http://example.org/11338843category25>;
+   bf:extent "2 microfilm reels ; 35 mm.";
+   bf:instanceOf <http://example.org/11338843work16>;
+   bf:instanceTitle <http://example.org/11338843title22>;
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1975";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Xerox University Microfilms,"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Ann Arbor, Mich. :"
+     ]
+   ] .
+
+<http://example.org/11338843category25> a bf:Category;
+   bf:categoryValue "Microfilm" .
+
+<http://example.org/11338843instance19> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "24-31 cm.";
+   bf:extent "27 v. ;";
+   bf:formDesignation "microform.";
+   bf:frequencyNote "Monthly (except Sept.), Aug./Sept. 1913-Feb. 1920";
+   bf:instanceOf <http://example.org/11338843>;
+   bf:instanceTitle <http://example.org/11338843title22>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sf 88091499"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Film incomplete: 1907-1920 wanting.",
+     "Title from cover.",
+     "Microfilm.";
+   bf:otherPhysicalFormat <http://example.org/11338843instance26>;
+   bf:providerStatement "Boston, Mass. : American Peace Society, 1894-1920.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1894-1920";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "American Peace Society"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Boston, Mass. "
+     ]
+   ];
+   bf:serialFirstIssue "Vol. 56, no. 1 (Jan. 1894)";
+   bf:serialLastIssue "v. 82, no. 2 (Feb. 1920).";
+   bf:systemNumber <http://www.worldcat.org/oclc/06215540>;
+   bf:title "Advocate of peace"@x-bf-sort;
+   bf:titleStatement "The Advocate of peace" .
+
+<http://example.org/11338843instance26> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/6797409>;
+   bf:title "Advocate of peace (1894)" .
+
+<http://example.org/11338843organization7> a bf:Organization;
+   bf:authorizedAccessPoint "American Peace Society.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "American Peace Society."
+   ];
+   bf:label "American Peace Society." .
+
+<http://example.org/11338843title6> a bf:Title;
+   bf:titleValue "Advocate of peace (1894)" .
+
+<http://example.org/11338843topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Peace--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Peace--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Peace";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Peace"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Peace--Periodicals" .
+
+<http://example.org/11338843topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Arbitration (International law)--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Arbitration (International law)--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Arbitration (International law)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Arbitration (International law)"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Arbitration (International law)--Periodicals" .
+
+<http://example.org/11338843topic9> a bf:Topic;
+   bf:authorizedAccessPoint "International relations--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "International relations--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "International relations";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "International relations"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "International relations--Periodicals" .
+
+<http://example.org/11338843work14> a bf:Work;
+   bf:authorizedAccessPoint "American advocate of peace (1893)";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sf88092312>;
+   bf:systemNumber <http://www.worldcat.org/oclc/7650660>;
+   bf:title "American advocate of peace (1893)" .
+
+<http://example.org/11338843work15> a bf:Work;
+   bf:authorizedAccessPoint "Advocate of peace through justice";
+   bf:systemNumber <http://www.worldcat.org/oclc/12953613>;
+   bf:title "Advocate of peace through justice" .
+
+<http://example.org/11338843> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "American Peace Society. Advocate of peace (1894)",
+     "americanpeacesocietyadvocateofpeace1894engworktext"@x-bf-hash;
+   bf:classificationDdc <http://dewey.info/class/051/about>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/Z6951>;
+   bf:continuedBy <http://example.org/11338843work15>;
+   bf:continues <http://example.org/11338843work14>;
+   bf:contributor <http://example.org/11338843organization7>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:reproduction <http://example.org/11338843work16>;
+   bf:subject <http://example.org/11338843topic9>,
+     <http://example.org/11338843topic10>,
+     <http://example.org/11338843topic11>;
+   bf:workTitle <http://example.org/11338843title6>;
+   mads:authoritativeLabel "Advocate of peace (1894)" .
+
+<http://example.org/11338843title22> a bf:Title;
+   bf:label "The Advocate of peace",
+     "The Advocate of peace [microform].";
+   bf:titleValue "The Advocate of peace" .
+
+<http://example.org/11338843work16> a bf:Work;
+   bf:authorizedAccessPoint "The Advocate of peace";
+   bf:title "The Advocate of peace" .

--- a/spec/fixtures/loc/m2b-properties/continues/11338843.marcxml
+++ b/spec/fixtures/loc/m2b-properties/continues/11338843.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01780cas a2200445 a 4500</leader>
   <controlfield tag="001">11338843</controlfield>
   <controlfield tag="005">20121214081036.0</controlfield>
@@ -134,4 +134,4 @@
     <subfield code="h">Microfilm 01104 no. 1544-1545 AP</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11338843</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/continues/11338843.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/continues/11338843.rdfxml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11338843">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>American Peace Society. Advocate of peace (1894)</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Advocate of peace (1894)</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/11338843title6"/>
+      <bf:contributor rdf:resource="http://example.org/11338843organization7"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic9"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic10"/>
+      <bf:subject rdf:resource="http://example.org/11338843topic11"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/Z6951"/>
+      <bf:classificationDdc rdf:resource="http://dewey.info/class/051/about"/>
+      <bf:continues rdf:resource="http://example.org/11338843work14"/>
+      <bf:continuedBy rdf:resource="http://example.org/11338843work15"/>
+      <bf:reproduction rdf:resource="http://example.org/11338843work16"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">americanpeacesocietyadvocateofpeace1894engworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work14">
+      <bf:title>American advocate of peace (1893)</bf:title>
+      <bf:authorizedAccessPoint>American advocate of peace (1893)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sf88092312"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/7650660"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work15">
+      <bf:title>Advocate of peace through justice</bf:title>
+      <bf:authorizedAccessPoint>Advocate of peace through justice</bf:authorizedAccessPoint>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/12953613"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11338843work16">
+      <bf:authorizedAccessPoint>The Advocate of peace</bf:authorizedAccessPoint>
+      <bf:title>The Advocate of peace</bf:title>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11338843instance20">
+      <bf:instanceTitle rdf:resource="http://example.org/11338843title22"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Ann Arbor, Mich. :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1975</bf:providerDate>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Xerox University Microfilms,</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+         </bf:Provider>
+      </bf:publication>
+      <bf:extent>2 microfilm reels ; 35 mm.</bf:extent>
+      <bf:carrierCategory rdf:resource="http://example.org/11338843category25"/>
+      <bf:instanceOf rdf:resource="http://example.org/11338843work16"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11338843instance19">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11338843title22"/>
+      <bf:title xml:lang="x-bf-sort">Advocate of peace</bf:title>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>American Peace Society</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Boston, Mass. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1894-1920</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11338843instance26"/>
+      <bf:extent>27 v. ;</bf:extent>
+      <bf:dimensions>24-31 cm.</bf:dimensions>
+      <bf:titleStatement>The Advocate of peace</bf:titleStatement>
+      <bf:formDesignation>microform.</bf:formDesignation>
+      <bf:providerStatement>Boston, Mass. : American Peace Society, 1894-1920.</bf:providerStatement>
+      <bf:frequencyNote>Monthly (except Sept.), Aug./Sept. 1913-Feb. 1920</bf:frequencyNote>
+      <bf:note>Film incomplete: 1907-1920 wanting.</bf:note>
+      <bf:note>Title from cover.</bf:note>
+      <bf:note>Microfilm.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sf 88091499</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/06215540"/>
+      <bf:serialFirstIssue>Vol. 56, no. 1 (Jan. 1894)</bf:serialFirstIssue>
+      <bf:serialLastIssue>v. 82, no. 2 (Feb. 1920).</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11338843"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11338843instance26">
+      <bf:title>Advocate of peace (1894)</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/6797409"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11338843annotation18">
+      <bf:derivedFrom rdf:resource="http://example.org/11338843.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/viblbv"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/pes"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2012-12-14T08:10</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11338843"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11338843helditem41">
+      <bf:label>Z6951 .A497 reel 1544-</bf:label>
+      <bf:shelfMarkLcc>Z6951 .A497 reel 1544-</bf:shelfMarkLcc>
+      <bf:shelfMarkDdc>051 A51p2</bf:shelfMarkDdc>
+      <bf:holdingFor rdf:resource="http://example.org/11338843instance19"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11338843title6">
+      <bf:titleValue>Advocate of peace (1894)</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/11338843organization7">
+      <bf:label>American Peace Society.</bf:label>
+      <bf:authorizedAccessPoint>American Peace Society.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>American Peace Society.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11338843topic9">
+      <bf:authorizedAccessPoint>International relations--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>International relations--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>International relations--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>International relations</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>International relations</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11338843topic10">
+      <bf:authorizedAccessPoint>Peace--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Peace--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Peace--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Peace</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Peace</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11338843topic11">
+      <bf:authorizedAccessPoint>Arbitration (International law)--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Arbitration (International law)--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Arbitration (International law)--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Arbitration (International law)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Arbitration (International law)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11338843title22">
+      <bf:label>The Advocate of peace</bf:label>
+   </bf:Title>
+   <bf:Category rdf:about="http://example.org/11338843category25">
+      <bf:categoryValue>Microfilm</bf:categoryValue>
+   </bf:Category>
+   <bf:Title rdf:about="http://example.org/11338843title22">
+      <bf:label>The Advocate of peace [microform].</bf:label>
+      <bf:titleValue>The Advocate of peace</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/continues/11338843.ttl
+++ b/spec/fixtures/loc/m2b-properties/continues/11338843.ttl
@@ -1,0 +1,216 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11338843annotation18> a bf:Annotation;
+   bf:annotates <http://example.org/11338843>;
+   bf:changeDate "2012-12-14T08:10";
+   bf:derivedFrom <http://example.org/11338843.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/pes>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/viblbv>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11338843helditem41> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11338843instance19>;
+   bf:label "Z6951 .A497 reel 1544-";
+   bf:shelfMarkDdc "051 A51p2";
+   bf:shelfMarkLcc "Z6951 .A497 reel 1544-" .
+
+<http://example.org/11338843instance20> a bf:Instance;
+   bf:carrierCategory <http://example.org/11338843category25>;
+   bf:extent "2 microfilm reels ; 35 mm.";
+   bf:instanceOf <http://example.org/11338843work16>;
+   bf:instanceTitle <http://example.org/11338843title22>;
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1975";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Xerox University Microfilms,"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Ann Arbor, Mich. :"
+     ]
+   ] .
+
+<http://example.org/11338843category25> a bf:Category;
+   bf:categoryValue "Microfilm" .
+
+<http://example.org/11338843instance19> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "24-31 cm.";
+   bf:extent "27 v. ;";
+   bf:formDesignation "microform.";
+   bf:frequencyNote "Monthly (except Sept.), Aug./Sept. 1913-Feb. 1920";
+   bf:instanceOf <http://example.org/11338843>;
+   bf:instanceTitle <http://example.org/11338843title22>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sf 88091499"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Film incomplete: 1907-1920 wanting.",
+     "Title from cover.",
+     "Microfilm.";
+   bf:otherPhysicalFormat <http://example.org/11338843instance26>;
+   bf:providerStatement "Boston, Mass. : American Peace Society, 1894-1920.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1894-1920";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "American Peace Society"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Boston, Mass. "
+     ]
+   ];
+   bf:serialFirstIssue "Vol. 56, no. 1 (Jan. 1894)";
+   bf:serialLastIssue "v. 82, no. 2 (Feb. 1920).";
+   bf:systemNumber <http://www.worldcat.org/oclc/06215540>;
+   bf:title "Advocate of peace"@x-bf-sort;
+   bf:titleStatement "The Advocate of peace" .
+
+<http://example.org/11338843instance26> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/6797409>;
+   bf:title "Advocate of peace (1894)" .
+
+<http://example.org/11338843organization7> a bf:Organization;
+   bf:authorizedAccessPoint "American Peace Society.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "American Peace Society."
+   ];
+   bf:label "American Peace Society." .
+
+<http://example.org/11338843title6> a bf:Title;
+   bf:titleValue "Advocate of peace (1894)" .
+
+<http://example.org/11338843topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Peace--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Peace--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Peace";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Peace"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Peace--Periodicals" .
+
+<http://example.org/11338843topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Arbitration (International law)--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Arbitration (International law)--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Arbitration (International law)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Arbitration (International law)"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Arbitration (International law)--Periodicals" .
+
+<http://example.org/11338843topic9> a bf:Topic;
+   bf:authorizedAccessPoint "International relations--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "International relations--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "International relations";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "International relations"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "International relations--Periodicals" .
+
+<http://example.org/11338843work14> a bf:Work;
+   bf:authorizedAccessPoint "American advocate of peace (1893)";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sf88092312>;
+   bf:systemNumber <http://www.worldcat.org/oclc/7650660>;
+   bf:title "American advocate of peace (1893)" .
+
+<http://example.org/11338843work15> a bf:Work;
+   bf:authorizedAccessPoint "Advocate of peace through justice";
+   bf:systemNumber <http://www.worldcat.org/oclc/12953613>;
+   bf:title "Advocate of peace through justice" .
+
+<http://example.org/11338843> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "American Peace Society. Advocate of peace (1894)",
+     "americanpeacesocietyadvocateofpeace1894engworktext"@x-bf-hash;
+   bf:classificationDdc <http://dewey.info/class/051/about>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/Z6951>;
+   bf:continuedBy <http://example.org/11338843work15>;
+   bf:continues <http://example.org/11338843work14>;
+   bf:contributor <http://example.org/11338843organization7>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:reproduction <http://example.org/11338843work16>;
+   bf:subject <http://example.org/11338843topic9>,
+     <http://example.org/11338843topic10>,
+     <http://example.org/11338843topic11>;
+   bf:workTitle <http://example.org/11338843title6>;
+   mads:authoritativeLabel "Advocate of peace (1894)" .
+
+<http://example.org/11338843title22> a bf:Title;
+   bf:label "The Advocate of peace",
+     "The Advocate of peace [microform].";
+   bf:titleValue "The Advocate of peace" .
+
+<http://example.org/11338843work16> a bf:Work;
+   bf:authorizedAccessPoint "The Advocate of peace";
+   bf:title "The Advocate of peace" .

--- a/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.marcxml
+++ b/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01793cas a2200409 a 4500</leader>
   <controlfield tag="001">13019979</controlfield>
   <controlfield tag="005">20130501082140.0</controlfield>
@@ -137,4 +137,4 @@
     <subfield code="e">db26 2004-05-05</subfield>
     <subfield code="g">db26 2004-05-05 to Ser</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13019979</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.rdfxml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/13019979">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Vital statistics supplement / State of Hawai'i, Department of Health.Vital statistics supplement</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/13019979title5"/>
+      <bf:creator rdf:resource="http://example.org/13019979jurisdiction6"/>
+      <bf:contributor rdf:resource="http://example.org/13019979jurisdiction7"/>
+      <bf:contentCategory rdf:resource="http://id.loc.gov/vocabulary/contentTypes/txt"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/13019979topic10"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us-hi"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/RA386"/>
+      <bf:continuesInPart rdf:resource="http://example.org/13019979work13"/>
+      <bf:supplementTo rdf:resource="http://example.org/13019979work14"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">hawaiidepartmentofhealthhawaiiofficeofhealthstatusmonitoringvitalstatisticssupplementengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13019979work13">
+      <bf:title>Annual report (1989). Statistical supplement</bf:title>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Annual report (1989). Statistical supplement</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn91034174"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/24280823"/>
+      <bf:contributor rdf:resource="http://example.org/13019979agent19"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13019979work14">
+      <bf:title>Annual report (1984)</bf:title>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Annual report (1984)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/87647860"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/14368386"/>
+      <bf:contributor rdf:resource="http://example.org/13019979agent20"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/13019979instance17">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/13019979title20"/>
+      <bf:titleVariation rdf:resource="http://example.org/13019979title21"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Dept. of Health, Office of Health Status Monitoring</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Honolulu </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1994-</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/13019979instance24"/>
+      <bf:extent>volumes :</bf:extent>
+      <bf:dimensions>28 cm</bf:dimensions>
+      <bf:illustrationNote>illustrations ;</bf:illustrationNote>
+      <bf:titleStatement>Vital statistics supplement</bf:titleStatement>
+      <bf:providerStatement>Honolulu : Dept. of Health, Office of Health Status Monitoring, 1994-</bf:providerStatement>
+      <bf:frequencyNote>Biennial</bf:frequencyNote>
+      <bf:note>"This is the statistical supplement to the narrative report published in a separate volume."</bf:note>
+      <bf:note>Latest issue consulted: 1995.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sn 95039821</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/31820559"/>
+      <bf:mediaCategory rdf:resource="http://id.loc.gov/vocabulary/mediaTypes/n"/>
+      <bf:carrierCategory rdf:resource="http://id.loc.gov/vocabulary/carriers/nc"/>
+      <bf:serialFirstIssue>1991</bf:serialFirstIssue>
+      <bf:serialLastIssue>1992-</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/13019979"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/13019979instance24">
+      <bf:title>Vital statistics supplement</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/732920129"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/13019979annotation16">
+      <bf:derivedFrom rdf:resource="http://example.org/13019979.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/cu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/n"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-05-01T08:21</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/13019979"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/13019979helditem40">
+      <bf:label>RA386 .H37a</bf:label>
+      <bf:shelfMarkLcc>RA386 .H37a</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/13019979instance17"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/13019979title5">
+      <bf:label>Vital statistics supplement / State of Hawai'i, Department of Health.</bf:label>
+      <bf:titleValue>Vital statistics supplement</bf:titleValue>
+   </bf:Title>
+   <bf:Jurisdiction rdf:about="http://example.org/13019979jurisdiction6">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Jurisdiction rdf:about="http://example.org/13019979jurisdiction7">
+      <bf:label>Hawaii. Office of Health Status Monitoring.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Office of Health Status Monitoring.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Office of Health Status Monitoring.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Topic rdf:about="http://example.org/13019979topic10">
+      <bf:authorizedAccessPoint>Vital statistics--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Vital statistics--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Vital statistics--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Vital statistics</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Vital statistics</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Agent rdf:about="http://example.org/13019979agent19">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/13019979agent20">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/13019979title20">
+      <bf:label>Vital statistics supplement / State of Hawai'i, Department of Health.</bf:label>
+      <bf:titleValue>Vital statistics supplement</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/13019979title21">
+      <bf:titleType>cover</bf:titleType>
+      <bf:label>Biennial report for ... Vital statistics supplement 1991-1992</bf:label>
+      <bf:titleValue>Biennial report for ...</bf:titleValue>
+      <bf:partTitle>Vital statistics supplement</bf:partTitle>
+      <bf:titleVariationDate>1991-1992</bf:titleVariationDate>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.ttl
+++ b/spec/fixtures/loc/m2b-properties/continuesInPart/13019979.ttl
@@ -1,0 +1,168 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/13019979annotation16> a bf:Annotation;
+   bf:annotates <http://example.org/13019979>;
+   bf:changeDate "2013-05-01T08:21";
+   bf:derivedFrom <http://example.org/13019979.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/n>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/cu>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/13019979helditem40> a bf:HeldItem;
+   bf:holdingFor <http://example.org/13019979instance17>;
+   bf:label "RA386 .H37a";
+   bf:shelfMarkLcc "RA386 .H37a" .
+
+<http://example.org/13019979agent19> a bf:Agent;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979agent20> a bf:Agent;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979instance17> a bf:Instance,
+     bf:Serial;
+   bf:carrierCategory <http://id.loc.gov/vocabulary/carriers/nc>;
+   bf:dimensions "28 cm";
+   bf:extent "volumes :";
+   bf:frequencyNote "Biennial";
+   bf:illustrationNote "illustrations ;";
+   bf:instanceOf <http://example.org/13019979>;
+   bf:instanceTitle <http://example.org/13019979title20>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sn 95039821"
+   ];
+   bf:mediaCategory <http://id.loc.gov/vocabulary/mediaTypes/n>;
+   bf:modeOfIssuance "serial";
+   bf:note "\"This is the statistical supplement to the narrative report published in a separate volume.\"",
+     "Latest issue consulted: 1995.";
+   bf:otherPhysicalFormat <http://example.org/13019979instance24>;
+   bf:providerStatement "Honolulu : Dept. of Health, Office of Health Status Monitoring, 1994-";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1994-";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Dept. of Health, Office of Health Status Monitoring"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Honolulu "
+     ]
+   ];
+   bf:serialFirstIssue "1991";
+   bf:serialLastIssue "1992-";
+   bf:systemNumber <http://www.worldcat.org/oclc/31820559>;
+   bf:titleStatement "Vital statistics supplement";
+   bf:titleVariation <http://example.org/13019979title21> .
+
+<http://example.org/13019979instance24> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/732920129>;
+   bf:title "Vital statistics supplement" .
+
+<http://example.org/13019979jurisdiction6> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979jurisdiction7> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Hawaii. Office of Health Status Monitoring.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Office of Health Status Monitoring."
+   ];
+   bf:label "Hawaii. Office of Health Status Monitoring." .
+
+<http://example.org/13019979title20> a bf:Title;
+   bf:label "Vital statistics supplement / State of Hawai'i, Department of Health.";
+   bf:titleValue "Vital statistics supplement" .
+
+<http://example.org/13019979title21> a bf:Title;
+   bf:label "Biennial report for ... Vital statistics supplement 1991-1992";
+   bf:partTitle "Vital statistics supplement";
+   bf:titleType "cover";
+   bf:titleValue "Biennial report for ...";
+   bf:titleVariationDate "1991-1992" .
+
+<http://example.org/13019979title5> a bf:Title;
+   bf:label "Vital statistics supplement / State of Hawai'i, Department of Health.";
+   bf:titleValue "Vital statistics supplement" .
+
+<http://example.org/13019979topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Vital statistics--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Vital statistics--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Vital statistics";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Vital statistics"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Vital statistics--Periodicals" .
+
+<http://example.org/13019979work13> a bf:Work;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Annual report (1989). Statistical supplement";
+   bf:contributor <http://example.org/13019979agent19>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn91034174>;
+   bf:systemNumber <http://www.worldcat.org/oclc/24280823>;
+   bf:title "Annual report (1989). Statistical supplement" .
+
+<http://example.org/13019979work14> a bf:Work;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Annual report (1984)";
+   bf:contributor <http://example.org/13019979agent20>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/87647860>;
+   bf:systemNumber <http://www.worldcat.org/oclc/14368386>;
+   bf:title "Annual report (1984)" .
+
+<http://example.org/13019979> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Vital statistics supplement / State of Hawai'i, Department of Health.Vital statistics supplement",
+     "hawaiidepartmentofhealthhawaiiofficeofhealthstatusmonitoringvitalstatisticssupplementengworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/RA386>;
+   bf:contentCategory <http://id.loc.gov/vocabulary/contentTypes/txt>;
+   bf:continuesInPart <http://example.org/13019979work13>;
+   bf:contributor <http://example.org/13019979jurisdiction7>;
+   bf:creator <http://example.org/13019979jurisdiction6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/13019979topic10>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us-hi>;
+   bf:supplementTo <http://example.org/13019979work14>;
+   bf:workTitle <http://example.org/13019979title5> .

--- a/spec/fixtures/loc/m2b-properties/contributor/13019979.marcxml
+++ b/spec/fixtures/loc/m2b-properties/contributor/13019979.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01793cas a2200409 a 4500</leader>
   <controlfield tag="001">13019979</controlfield>
   <controlfield tag="005">20130501082140.0</controlfield>
@@ -137,4 +137,4 @@
     <subfield code="e">db26 2004-05-05</subfield>
     <subfield code="g">db26 2004-05-05 to Ser</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13019979</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/copyNote/11134216.marcxml
+++ b/spec/fixtures/loc/m2b-properties/copyNote/11134216.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>09110cas a2201645 a 4500</leader>
   <controlfield tag="001">11134216</controlfield>
   <controlfield tag="005">20130620075454.0</controlfield>
@@ -852,4 +852,4 @@
     <subfield code="v">509 1990 May * 8888</subfield>
     <subfield code="w">CCF</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11134216</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/copyNote/16122784.marcxml
+++ b/spec/fixtures/loc/m2b-properties/copyNote/16122784.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01848cam a2200505 a 4500</leader>
   <controlfield tag="001">16122784</controlfield>
   <controlfield tag="005">20110927111652.0</controlfield>
@@ -155,4 +155,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16122784</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/copyrightDate/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/copyrightDate/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/creator/11185095.marcxml
+++ b/spec/fixtures/loc/m2b-properties/creator/11185095.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02048cas a2200457 a 4500</leader>
   <controlfield tag="001">11185095</controlfield>
   <controlfield tag="005">20121213075511.0</controlfield>
@@ -144,4 +144,4 @@
     <subfield code="b">B/L</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11185095</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/creditsNote/12241297.marcxml
+++ b/spec/fixtures/loc/m2b-properties/creditsNote/12241297.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01873cjm a22003731a 4500</leader>
   <controlfield tag="001">12241297</controlfield>
   <controlfield tag="005">20121019141547.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">srreplace 2003-01</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12241297</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/custodialHistory/14825804.marcxml
+++ b/spec/fixtures/loc/m2b-properties/custodialHistory/14825804.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02780ctc a22003977a 4500</leader>
   <controlfield tag="001">14825804</controlfield>
   <controlfield tag="005">20080609082523.0</controlfield>
@@ -125,4 +125,4 @@
   <datafield tag="730" ind1="0" ind2=" ">
     <subfield code="a">Friend (Bloemfontein, South Africa)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14825804</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/custodialHistory/17125262.marcxml
+++ b/spec/fixtures/loc/m2b-properties/custodialHistory/17125262.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01944cas a2200433 a 4500</leader>
   <controlfield tag="001">17125262</controlfield>
   <controlfield tag="005">20120313155919.0</controlfield>
@@ -136,4 +136,4 @@
     <subfield code="a">fe00 2012-01-18</subfield>
     <subfield code="i">fe04 2012-01-18 (EurRR uncataloged serials) to BCCD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17125262</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dataSource/14422529.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dataSource/14422529.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02650cas a2200481 a 4500</leader>
   <controlfield tag="001">14422529</controlfield>
   <controlfield tag="005">20130508075956.0</controlfield>
@@ -169,4 +169,4 @@
     <subfield code="a">Barcode 00180814012 returned from bindery 2009-10-06</subfield>
     <subfield code="a">Barcode 00286437254 returned from bindery 2010-06-04</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14422529</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dataSource/14422529.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/dataSource/14422529.rdfxml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/14422529">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā. Annual report of the Earth Simulator Center.Annual report of the Earth Simulator Center</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/14422529title5"/>
+      <bf:creator rdf:resource="http://example.org/14422529organization6"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>1348-5822</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:contentCategory rdf:resource="http://id.loc.gov/vocabulary/contentTypes/txt"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:language rdf:resource="http://example.org/14422529language10"/>
+      <bf:language rdf:resource="http://example.org/14422529language11"/>
+      <bf:subject rdf:resource="http://example.org/14422529topic12"/>
+      <bf:subject rdf:resource="http://example.org/14422529topic13"/>
+      <bf:subject rdf:resource="http://example.org/14422529topic14"/>
+      <bf:subject rdf:resource="http://example.org/14422529organization15"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/QC981.8.C5"/>
+      <bf:classification rdf:resource="http://example.org/14422529classification17"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>1348-5822</bf:identifierValue>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">kaiyōkenkyūkaihatsukikōjapanchikyūshimurētasentāannualreportoftheearthsimulatorcenterengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/14422529instance21">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/14422529title25"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Japan Agency for Marine-Earth Science and Technology, the Earth Simulator Center</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Yokohama? </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+         </bf:Provider>
+      </bf:publication>
+      <bf:soundContent>Unknown</bf:soundContent>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/14422529instance29"/>
+      <bf:extent>volumes :</bf:extent>
+      <bf:dimensions>30 cm</bf:dimensions>
+      <bf:illustrationNote>illustrations ;</bf:illustrationNote>
+      <bf:titleStatement>Annual report of the Earth Simulator Center.</bf:titleStatement>
+      <bf:providerStatement>Yokohama? : Japan Agency for Marine-Earth Science and Technology, the Earth Simulator Center</bf:providerStatement>
+      <bf:frequencyNote>Annual</bf:frequencyNote>
+      <bf:languageNote>Text in English; summaries and tables of contents also in Japanese &lt;Apr. 2004/Mar. 2005-&gt;.</bf:languageNote>
+      <bf:note>Latest issue consulted: Apr. 2004/Mar. 2005.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2007209546</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>981803393</bf:identifierValue>
+            <bf:identifierAssigner>DE-101</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>2257447-5</bf:identifierValue>
+            <bf:identifierAssigner>DE-600</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>1348-5822</bf:identifierValue>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/68135417"/>
+      <bf:mediaCategory rdf:resource="http://id.loc.gov/vocabulary/mediaTypes/n"/>
+      <bf:carrierCategory rdf:resource="http://id.loc.gov/vocabulary/carriers/nc"/>
+      <bf:serialFirstIssue>Apr. 2003/Mar. 2004</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/14422529"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/14422529instance29">
+      <bf:title>Annual report of the Earth Simulator Center</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/655499790"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/14422529instance22">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <bf:label>Electronic Resource</bf:label>
+      <bf:uri rdf:resource="http://bibpurl.oclc.org/web/13129"/>
+      <bf:uri rdf:resource="http://www.es.jamstec.go.jp/esc/eng/publications/index.html"/>
+      <bf:instanceOf rdf:resource="http://example.org/14422529"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/14422529annotation20">
+      <bf:derivedFrom rdf:resource="http://example.org/14422529.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/cus"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/cus"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/gbvcp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-05-08T07:59</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/14422529"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/14422529helditem47">
+      <bf:label>QC981.8.C5 K35a</bf:label>
+      <bf:shelfMarkLcc>QC981.8.C5 K35a</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/14422529instance21"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/14422529title5">
+      <bf:label>Annual report of the Earth Simulator Center.</bf:label>
+      <bf:titleValue>Annual report of the Earth Simulator Center</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/14422529organization6">
+      <bf:label>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā.</bf:label>
+      <bf:authorizedAccessPoint>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Language rdf:about="http://example.org/14422529language10">
+      <bf:resourcePart>summary or abstract</bf:resourcePart>
+      <bf:languageOfPartUri rdf:resource="http://id.loc.gov/vocabulary/languages/jpn"/>
+   </bf:Language>
+   <bf:Language rdf:about="http://example.org/14422529language11">
+      <bf:resourcePart>table of contents</bf:resourcePart>
+      <bf:languageOfPartUri rdf:resource="http://id.loc.gov/vocabulary/languages/jpn"/>
+   </bf:Language>
+   <bf:Topic rdf:about="http://example.org/14422529topic12">
+      <bf:authorizedAccessPoint>Climatic changes--Computer simulation--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Climatic changes--Computer simulation--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Climatic changes--Computer simulation--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Climatic changes</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Climatic changes</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Computer simulation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Computer simulation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14422529topic13">
+      <bf:authorizedAccessPoint>Earth sciences--Computer simulation--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Earth sciences--Computer simulation--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Earth sciences--Computer simulation--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Earth sciences</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Earth sciences</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Computer simulation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Computer simulation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14422529topic14">
+      <bf:authorizedAccessPoint>Ocean-atmosphere interaction--Computer simulation--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Ocean-atmosphere interaction--Computer simulation--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Ocean-atmosphere interaction--Computer simulation--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Ocean-atmosphere interaction</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Ocean-atmosphere interaction</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Computer simulation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Computer simulation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Organization rdf:about="http://example.org/14422529organization15">
+      <bf:authorizedAccessPoint>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals.</bf:authorizedAccessPoint>
+      <bf:label>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:CorporateName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>Kaiyō Kenkyū Kaihatsu Kikō (Japan).</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>Chikyū Shimurēta Sentā</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                  </madsrdf:elementList>
+               </madsrdf:CorporateName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Classification rdf:about="http://example.org/14422529classification17">
+      <bf:classificationScheme>bcl</bf:classificationScheme>
+      <bf:classificationNumber>38.59</bf:classificationNumber>
+      <bf:label>38.59</bf:label>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/14422529title25">
+      <bf:label>Annual report of the Earth Simulator Center.</bf:label>
+      <bf:titleValue>Annual report of the Earth Simulator Center</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/dataSource/14422529.ttl
+++ b/spec/fixtures/loc/m2b-properties/dataSource/14422529.ttl
@@ -1,0 +1,278 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/14422529annotation20> a bf:Annotation;
+   bf:annotates <http://example.org/14422529>;
+   bf:changeDate "2013-05-08T07:59";
+   bf:derivedFrom <http://example.org/14422529.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/cus>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/gbvcp>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/cus>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/14422529helditem47> a bf:HeldItem;
+   bf:holdingFor <http://example.org/14422529instance21>;
+   bf:label "QC981.8.C5 K35a";
+   bf:shelfMarkLcc "QC981.8.C5 K35a" .
+
+<http://example.org/14422529instance22> a bf:Instance,
+     bf:Electronic;
+   bf:instanceOf <http://example.org/14422529>;
+   bf:label "Electronic Resource";
+   bf:uri <http://bibpurl.oclc.org/web/13129>,
+     <http://www.es.jamstec.go.jp/esc/eng/publications/index.html> .
+
+<http://example.org/14422529classification17> a bf:Classification;
+   bf:classificationNumber "38.59";
+   bf:classificationScheme "bcl";
+   bf:label "38.59" .
+
+<http://example.org/14422529instance21> a bf:Instance,
+     bf:Electronic,
+     bf:Serial;
+   bf:carrierCategory <http://id.loc.gov/vocabulary/carriers/nc>;
+   bf:dimensions "30 cm";
+   bf:extent "volumes :";
+   bf:frequencyNote "Annual";
+   bf:illustrationNote "illustrations ;";
+   bf:instanceOf <http://example.org/14422529>;
+   bf:instanceTitle <http://example.org/14422529title25>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "1348-5822"
+   ];
+   bf:languageNote "Text in English; summaries and tables of contents also in Japanese <Apr. 2004/Mar. 2005->.";
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2007209546"
+   ];
+   bf:mediaCategory <http://id.loc.gov/vocabulary/mediaTypes/n>;
+   bf:modeOfIssuance "serial";
+   bf:nban [
+     a bf:Identifier;
+     bf:identifierAssigner "DE-101";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "981803393"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "DE-600";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "2257447-5"
+   ];
+   bf:note "Latest issue consulted: Apr. 2004/Mar. 2005.";
+   bf:otherPhysicalFormat <http://example.org/14422529instance29>;
+   bf:providerStatement "Yokohama? : Japan Agency for Marine-Earth Science and Technology, the Earth Simulator Center";
+   bf:publication [
+     a bf:Provider;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Japan Agency for Marine-Earth Science and Technology, the Earth Simulator Center"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Yokohama? "
+     ]
+   ];
+   bf:serialFirstIssue "Apr. 2003/Mar. 2004";
+   bf:soundContent "Unknown";
+   bf:systemNumber <http://www.worldcat.org/oclc/68135417>;
+   bf:titleStatement "Annual report of the Earth Simulator Center." .
+
+<http://example.org/14422529instance29> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/655499790>;
+   bf:title "Annual report of the Earth Simulator Center" .
+
+<http://example.org/14422529language10> a bf:Language;
+   bf:languageOfPartUri <http://id.loc.gov/vocabulary/languages/jpn>;
+   bf:resourcePart "summary or abstract" .
+
+<http://example.org/14422529language11> a bf:Language;
+   bf:languageOfPartUri <http://id.loc.gov/vocabulary/languages/jpn>;
+   bf:resourcePart "table of contents" .
+
+<http://example.org/14422529organization15> a bf:Organization;
+   bf:authorizedAccessPoint "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals.";
+     mads:componentList ([
+         a mads:CorporateName,
+           mads:Authority;
+         mads:authoritativeLabel "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā";
+         mads:elementList ([
+             a mads:NameElement;
+             mads:elementValue "Kaiyō Kenkyū Kaihatsu Kikō (Japan)."
+           ] [
+             a mads:NameElement;
+             mads:elementValue "Chikyū Shimurēta Sentā"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā--Periodicals." .
+
+<http://example.org/14422529organization6> a bf:Organization;
+   bf:authorizedAccessPoint "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā."
+   ];
+   bf:label "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā." .
+
+<http://example.org/14422529title25> a bf:Title;
+   bf:label "Annual report of the Earth Simulator Center.";
+   bf:titleValue "Annual report of the Earth Simulator Center" .
+
+<http://example.org/14422529title5> a bf:Title;
+   bf:label "Annual report of the Earth Simulator Center.";
+   bf:titleValue "Annual report of the Earth Simulator Center" .
+
+<http://example.org/14422529topic12> a bf:Topic;
+   bf:authorizedAccessPoint "Climatic changes--Computer simulation--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Climatic changes--Computer simulation--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Climatic changes";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Climatic changes"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Computer simulation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Computer simulation"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Climatic changes--Computer simulation--Periodicals" .
+
+<http://example.org/14422529topic13> a bf:Topic;
+   bf:authorizedAccessPoint "Earth sciences--Computer simulation--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Earth sciences--Computer simulation--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Earth sciences";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Earth sciences"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Computer simulation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Computer simulation"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Earth sciences--Computer simulation--Periodicals" .
+
+<http://example.org/14422529topic14> a bf:Topic;
+   bf:authorizedAccessPoint "Ocean-atmosphere interaction--Computer simulation--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Ocean-atmosphere interaction--Computer simulation--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Ocean-atmosphere interaction";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Ocean-atmosphere interaction"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Computer simulation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Computer simulation"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Ocean-atmosphere interaction--Computer simulation--Periodicals" .
+
+<http://example.org/14422529> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Kaiyō Kenkyū Kaihatsu Kikō (Japan). Chikyū Shimurēta Sentā. Annual report of the Earth Simulator Center.Annual report of the Earth Simulator Center",
+     "kaiyōkenkyūkaihatsukikōjapanchikyūshimurētasentāannualreportoftheearthsimulatorcenterengworktext"@x-bf-hash;
+   bf:classification <http://example.org/14422529classification17>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/QC981.8.C5>;
+   bf:contentCategory <http://id.loc.gov/vocabulary/contentTypes/txt>;
+   bf:creator <http://example.org/14422529organization6>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "1348-5822"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "1348-5822"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>,
+     <http://example.org/14422529language10>,
+     <http://example.org/14422529language11>;
+   bf:subject <http://example.org/14422529topic12>,
+     <http://example.org/14422529topic13>,
+     <http://example.org/14422529topic14>,
+     <http://example.org/14422529organization15>;
+   bf:workTitle <http://example.org/14422529title5> .

--- a/spec/fixtures/loc/m2b-properties/derivedFrom/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/derivedFrom/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/descriptionConventions/6954995.marcxml
+++ b/spec/fixtures/loc/m2b-properties/descriptionConventions/6954995.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01927cam a2200373 a 4500</leader>
   <controlfield tag="001">6954995</controlfield>
   <controlfield tag="005">20130507075236.0</controlfield>
@@ -113,4 +113,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=6954995</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/descriptionLanguage/11176633.marcxml
+++ b/spec/fixtures/loc/m2b-properties/descriptionLanguage/11176633.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04806cas a2200913 a 4500</leader>
   <controlfield tag="001">11176633</controlfield>
   <controlfield tag="005">20140405155747.0</controlfield>
@@ -441,4 +441,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11176633</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/descriptionSource/11176633.marcxml
+++ b/spec/fixtures/loc/m2b-properties/descriptionSource/11176633.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04806cas a2200913 a 4500</leader>
   <controlfield tag="001">11176633</controlfield>
   <controlfield tag="005">20140405155747.0</controlfield>
@@ -441,4 +441,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11176633</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dimensions/11510969.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dimensions/11510969.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>06686cgm a2201249 a 4500</leader>
   <controlfield tag="001">11510969</controlfield>
   <controlfield tag="005">20140812152343.0</controlfield>
@@ -407,4 +407,4 @@
     <subfield code="h">CQA 0534-0546 (neg trk)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11510969</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dimensions/15875548.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dimensions/15875548.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01116cam a22002894a 4500</leader>
   <controlfield tag="001">15875548</controlfield>
   <controlfield tag="005">20150423131224.0</controlfield>
@@ -86,4 +86,4 @@
     <subfield code="y">20th century</subfield>
     <subfield code="x">History and criticism.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15875548</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationDegree/16684455.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationDegree/16684455.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01532cam a2200313 a 4500</leader>
   <controlfield tag="001">16684455</controlfield>
   <controlfield tag="005">20120622113842.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="x">History</subfield>
     <subfield code="y">13th century.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16684455</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationIdentifier/15535030.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationIdentifier/15535030.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02295cam a22004217a 4500</leader>
   <controlfield tag="001">15535030</controlfield>
   <controlfield tag="005">20120329103747.0</controlfield>
@@ -169,4 +169,4 @@
     <subfield code="a">Reser series</subfield>
     <subfield code="x">0123-4567</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15535030</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationInstitution/16684455.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationInstitution/16684455.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01532cam a2200313 a 4500</leader>
   <controlfield tag="001">16684455</controlfield>
   <controlfield tag="005">20120622113842.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="x">History</subfield>
     <subfield code="y">13th century.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16684455</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationNote/16684455.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationNote/16684455.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01532cam a2200313 a 4500</leader>
   <controlfield tag="001">16684455</controlfield>
   <controlfield tag="005">20120622113842.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="x">History</subfield>
     <subfield code="y">13th century.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16684455</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationNote/16872934.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationNote/16872934.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01523cam a2200361 a 4500</leader>
   <controlfield tag="001">16872934</controlfield>
   <controlfield tag="005">20111215102400.0</controlfield>
@@ -110,4 +110,4 @@
   <datafield tag="856" ind1="4" ind2="1">
     <subfield code="u">http://urn.kb.se/resolve?urn=urn:nbn:se:umu:diva-1450</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16872934</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/dissertationYear/16684455.marcxml
+++ b/spec/fixtures/loc/m2b-properties/dissertationYear/16684455.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01532cam a2200313 a 4500</leader>
   <controlfield tag="001">16684455</controlfield>
   <controlfield tag="005">20120622113842.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="x">History</subfield>
     <subfield code="y">13th century.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16684455</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/doi/15943756.marcxml
+++ b/spec/fixtures/loc/m2b-properties/doi/15943756.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01745cam a22004217a 4500</leader>
   <controlfield tag="001">15943756</controlfield>
   <controlfield tag="005">20120419080657.0</controlfield>
@@ -135,4 +135,4 @@
     <subfield code="a">xh00 2010-05-10 to USPL/STM</subfield>
     <subfield code="a">xh00 2010-08-26 to USPL/STM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15943756</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/doi/16866807.marcxml
+++ b/spec/fixtures/loc/m2b-properties/doi/16866807.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02366cam a22004695a 4500</leader>
   <controlfield tag="001">16866807</controlfield>
   <controlfield tag="005">20130521070408.0</controlfield>
@@ -148,4 +148,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1304/2011282795-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16866807</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/duration/12076972.marcxml
+++ b/spec/fixtures/loc/m2b-properties/duration/12076972.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01747cjm a22003731a 4500</leader>
   <controlfield tag="001">12076972</controlfield>
   <controlfield tag="005">20000624075139.0</controlfield>
@@ -104,4 +104,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">Claimed Recordings</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12076972</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/ean/17332794.marcxml
+++ b/spec/fixtures/loc/m2b-properties/ean/17332794.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01097cgm a22003135a 4500</leader>
   <controlfield tag="001">17332794</controlfield>
   <controlfield tag="005">20120605144630.0</controlfield>
@@ -83,4 +83,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">Nacionalni ansambl Kolo.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17332794</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/edition/13850373.marcxml
+++ b/spec/fixtures/loc/m2b-properties/edition/13850373.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01564cam a2200409 a 4500</leader>
   <controlfield tag="001">13850373</controlfield>
   <controlfield tag="005">20070824223516.0</controlfield>
@@ -132,4 +132,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13850373</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/edition/6202824.marcxml
+++ b/spec/fixtures/loc/m2b-properties/edition/6202824.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01143cam a22002891  4500</leader>
   <controlfield tag="001">6202824</controlfield>
   <controlfield tag="005">20000118121243.0</controlfield>
@@ -83,4 +83,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=6202824</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/edition/9111141.marcxml
+++ b/spec/fixtures/loc/m2b-properties/edition/9111141.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01110nam a22002057  4500</leader>
   <controlfield tag="001">9111141</controlfield>
   <controlfield tag="005">00000000000000.0</controlfield>
@@ -55,4 +55,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=9111141</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/editionResponsibility/9111141.marcxml
+++ b/spec/fixtures/loc/m2b-properties/editionResponsibility/9111141.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01110nam a22002057  4500</leader>
   <controlfield tag="001">9111141</controlfield>
   <controlfield tag="005">00000000000000.0</controlfield>
@@ -55,4 +55,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=9111141</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/event/16937135.marcxml
+++ b/spec/fixtures/loc/m2b-properties/event/16937135.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02690cgm a22003853a 4500</leader>
   <controlfield tag="001">16937135</controlfield>
   <controlfield tag="005">20140508102912.0</controlfield>
@@ -108,4 +108,4 @@
     <subfield code="w">(DLC) 1840309</subfield>
     <subfield code="n">MAVIS.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16937135</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/event/5795097.marcxml
+++ b/spec/fixtures/loc/m2b-properties/event/5795097.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02214cjm a2200469 a 4500</leader>
   <controlfield tag="001">5795097</controlfield>
   <controlfield tag="005">20130502115120.0</controlfield>
@@ -144,4 +144,4 @@
     <subfield code="h">Strings QT 99.360/1</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5795097</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/eventDate/11785748.marcxml
+++ b/spec/fixtures/loc/m2b-properties/eventDate/11785748.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01353cjm a2200301 a 4500</leader>
   <controlfield tag="001">11785748</controlfield>
   <controlfield tag="005">19990929152642.0</controlfield>
@@ -85,4 +85,4 @@
     <subfield code="d">1899-1974.</subfield>
     <subfield code="4">prf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11785748</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/eventDate/14505575.marcxml
+++ b/spec/fixtures/loc/m2b-properties/eventDate/14505575.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02188cjm a2200505 a 4500</leader>
   <controlfield tag="001">14505575</controlfield>
   <controlfield tag="005">20081120094448.0</controlfield>
@@ -159,4 +159,4 @@
     <subfield code="a">S&#x30C;ta&#x301;tna filharmo&#x301;nia (Kos&#x30C;ice, Slovakia)</subfield>
     <subfield code="4">prf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14505575</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/eventDate/5795097.marcxml
+++ b/spec/fixtures/loc/m2b-properties/eventDate/5795097.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02214cjm a2200469 a 4500</leader>
   <controlfield tag="001">5795097</controlfield>
   <controlfield tag="005">20130502115120.0</controlfield>
@@ -144,4 +144,4 @@
     <subfield code="h">Strings QT 99.360/1</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5795097</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/eventPlace/16937135.marcxml
+++ b/spec/fixtures/loc/m2b-properties/eventPlace/16937135.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02690cgm a22003853a 4500</leader>
   <controlfield tag="001">16937135</controlfield>
   <controlfield tag="005">20140508102912.0</controlfield>
@@ -108,4 +108,4 @@
     <subfield code="w">(DLC) 1840309</subfield>
     <subfield code="n">MAVIS.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16937135</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/extent/15875548.marcxml
+++ b/spec/fixtures/loc/m2b-properties/extent/15875548.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01116cam a22002894a 4500</leader>
   <controlfield tag="001">15875548</controlfield>
   <controlfield tag="005">20150423131224.0</controlfield>
@@ -86,4 +86,4 @@
     <subfield code="y">20th century</subfield>
     <subfield code="x">History and criticism.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15875548</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/findingAid/11628622.marcxml
+++ b/spec/fixtures/loc/m2b-properties/findingAid/11628622.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>07792ckc a2201081 a 4500</leader>
   <controlfield tag="001">11628622</controlfield>
   <controlfield tag="005">20150626082430.0</controlfield>
@@ -386,4 +386,4 @@
     <subfield code="v">obj.</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11628622</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/findingAid/11628622.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/findingAid/11628622.rdfxml
@@ -1,0 +1,1476 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11628622">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/StillImage"/>
+      <bf:authorizedAccessPoint>Bransby, David Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11628622title5"/>
+      <relators:pht rdf:resource="http://example.org/11628622person6"/>
+      <relators:pht rdf:resource="http://example.org/11628622person7"/>
+      <relators:pht rdf:resource="http://example.org/11628622person8"/>
+      <relators:pht rdf:resource="http://example.org/11628622person9"/>
+      <relators:pht rdf:resource="http://example.org/11628622person10"/>
+      <relators:pht rdf:resource="http://example.org/11628622person11"/>
+      <relators:pht rdf:resource="http://example.org/11628622person12"/>
+      <relators:pht rdf:resource="http://example.org/11628622person13"/>
+      <relators:pht rdf:resource="http://example.org/11628622person14"/>
+      <relators:pht rdf:resource="http://example.org/11628622person15"/>
+      <relators:pht rdf:resource="http://example.org/11628622person16"/>
+      <relators:pht rdf:resource="http://example.org/11628622person17"/>
+      <relators:pht rdf:resource="http://example.org/11628622person18"/>
+      <relators:pht rdf:resource="http://example.org/11628622person19"/>
+      <relators:pht rdf:resource="http://example.org/11628622person20"/>
+      <relators:pht rdf:resource="http://example.org/11628622person21"/>
+      <relators:pht rdf:resource="http://example.org/11628622person22"/>
+      <relators:pht rdf:resource="http://example.org/11628622person23"/>
+      <relators:pht rdf:resource="http://example.org/11628622person24"/>
+      <relators:pht rdf:resource="http://example.org/11628622person25"/>
+      <bf:contributor rdf:resource="http://example.org/11628622jurisdiction26"/>
+      <bf:contributor rdf:resource="http://example.org/11628622jurisdiction27"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:index rdf:resource="http://example.org/11628622work29"/>
+      <bf:subject rdf:resource="http://example.org/11628622organization31"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic32"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic33"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic34"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic35"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic36"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic37"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic38"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic39"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic40"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic41"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic42"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic43"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic44"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic45"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic46"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic47"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic48"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic49"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic50"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic51"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic52"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic53"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic54"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic55"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic56"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic57"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic58"/>
+      <bf:subject rdf:resource="http://example.org/11628622topic59"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us"/>
+      <bf:relatedWork rdf:resource="http://example.org/11628622work61"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">bransbydavidcollinsmarjory19121985collierjohnjr19131992delanojackdixonroydendowneyjackfeiningerandreas19061999hollemhowardrjacobsfenno19041975leerussell19031986libermanhowardpalmeralfredtrittasewilliamm18941968rosskamlouise19102003rothsteinarthur19151985rousjohnsherwoodmarksiegelarthursvachonjohn19141975wolcottmarionpost19101990unitedstatesfarmsecurityadministrationunitedstatesofficeofwarinformationfarmsecurityadministrationofficeofwarinformationcolorslidesandtransparenciescollectionlibraryofcongressengworkstillimage</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11628622work29">
+      <bf:authorizedAccessPoint>A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See</bf:authorizedAccessPoint>
+      <bf:title>A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See</bf:title>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11628622work61">
+      <bf:title>America from the great depression to World War II: color photographs from the FSA-OWI, 1939-1945.</bf:title>
+      <bf:authorizedAccessPoint>America from the great depression to World War II: color photographs from the FSA-OWI, 1939-1945.</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11628622instance33">
+      <bf:hdl rdf:resource="http://hdl.loc.gov/loc.gdc/lcoa1.about"/>
+      <bf:instanceOf rdf:resource="http://example.org/11628622work29"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11628622instance64">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Collection"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11628622title68"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:copyrightDate>1939-1944</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:soundContent>Unknown</bf:soundContent>
+      <bf:soundContent>Unknown</bf:soundContent>
+      <bf:soundContent>Unknown</bf:soundContent>
+      <bf:soundContent>Unknown</bf:soundContent>
+      <bf:modeOfIssuance>monographic</bf:modeOfIssuance>
+      <bf:extent>1,616 transparencies (film and slides) :</bf:extent>
+      <bf:dimensions>4 x 5 in. or smaller.</bf:dimensions>
+      <bf:illustrationNote>color ;</bf:illustrationNote>
+      <bf:titleStatement>Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)</bf:titleStatement>
+      <bf:formDesignation>graphic.</bf:formDesignation>
+      <bf:providerStatement>1939-1944.</bf:providerStatement>
+      <bf:accessCondition>Please use online digital copies instead of original material, following Division's preservation policy.</bf:accessCondition>
+      <bf:immediateAcquisition>Transfer; U.S. Office of War Information; 1944.</bf:immediateAcquisition>
+      <bf:note>Documentary images of life and culture in the United States, Puerto Rico, and the U.S. Virgin Islands. Farm Security Administration images focus on rural areas, depicting farming, mining, forestry, migrant labor, children, and fairs. Includes particularly extensive coverage of Afro-Americans, but also includes whites, Hispanic Americans, and islanders. Office of War Information images cover civilian training during World War II, civil engineering (especially dam construction and operation of the Tennessee Valley Authority), factories and industrial labor, women working in the defense industry, transportation (particularly by railroad and by air), World War II mobilization, military facilities (with an emphasis on air bases), scenes related to national security and civil service, and war industries. Includes scenes of mountains, rivers, forests, other natural features, and towns. Also includes some historic sites and monuments.</bf:note>
+      <bf:note>The U.S. Farm Security Administration (FSA) was created in the Department of Agriculture in 1937. The FSA and its predecessor, the Resettlement Administration (RA), were New Deal programs designed to assist poor farmers working in the Dust Bowl and during the Great Depression. The U.S. Office of War Information (OWI) was created in 1942 to be a U.S. government propaganda agency during World War II. The images created by these agencies during this period are among the earliest color film photographs used for documentary purpose. Many of the assignments covered in color were also covered in black and white.</bf:note>
+      <bf:note>Digitized images of all items in the collection and their associated identifying information are available through the Prints &amp; Photographs Online Catalog,</bf:note>
+      <bf:note>Digitized images were also available through the Library of Congress American Memory Web site published in 1996 and closed in 2013; called: America from the Great Depression to World War II: color photographs from the FSA-OWI, 1939-1945.</bf:note>
+      <bf:note>B&amp;w reference copy prints are LOT 11671 and LOT 12002.</bf:note>
+      <bf:note>Collection title devised by Library staff.</bf:note>
+      <bf:note>Photographers are: David Bransby (1942), John Collier (1942-1943), Marjory Collins (1943), Jack Delano (1940-1943), Royden Dixon (1941-1942), Jack Downey (1944), Andreas Feininger (1942), Howard R. Hollem (ca. 1941-1945), Fenno Jacobs (1942), Russell Lee (1940-1942), Howard Liberman (1942), Alfred T. Palmer (1941-1943), William M. Rittase (1942), Louise Rosskam (1941-1942), Arthur Rothstein (1942), John Rous (1941), Mark Sherwood (1942), Arthur S. Siegel (1942), John Vachon (1939-1942), and Marion Post Wolcott (1939-1941).</bf:note>
+      <bf:note>Includes 550 35mm slides; the other transparencies are larger format: 2 1/2 x 2 1/2, 3x4, and 4x5 inches. The type of film is Kodachrome.</bf:note>
+      <bf:note>Published in: Bound for glory: America in color, 1939-43 / Essay by Paul Hendrickson. New York : H.N. Abrams, 2004.</bf:note>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>11628622</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>93845501</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:arrangement rdf:resource="http://example.org/11628622arrangement94"/>
+      <bf:instanceOf rdf:resource="http://example.org/11628622"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11628622instance65">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <bf:label>Electronic Resource</bf:label>
+      <bf:hdl rdf:resource="http://hdl.loc.gov/loc.pnp/pp.fsac"/>
+      <bf:instanceOf rdf:resource="http://example.org/11628622"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11628622annotation63">
+      <bf:derivedFrom rdf:resource="http://example.org/11628622.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/gihc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2015-06-26T08:24</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11628622"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11628622helditem96">
+      <bf:label/>
+      <bf:heldBy>Library of Congress</bf:heldBy>
+      <bf:subLocation>Prints and Photographs Division</bf:subLocation>
+      <bf:hdl rdf:resource="http://hdl.loc.gov/loc.pnp/pp.print"/>
+      <bf:holdingFor rdf:resource="http://example.org/11628622instance64"/>
+   </bf:HeldItem>
+   <bf:Summary rdf:about="http://example.org/11628622summary30">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Summary"/>
+      <bf:label>Summary</bf:label>
+      <bf:annotationAssertedBy rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:annotationBody>Documentary images of life and culture in the United States, Puerto Rico, and the U.S. Virgin Islands. Farm Security Administration images focus on rural areas, depicting farming, mining, forestry, migrant labor, children, and fairs. Includes particularly extensive coverage of Afro-Americans, but also includes whites, Hispanic Americans, and islanders. Office of War Information images cover civilian training during World War II, civil engineering (especially dam construction and operation of the Tennessee Valley Authority), factories and industrial labor, women working in the defense industry, transportation (particularly by railroad and by air), World War II mobilization, military facilities (with an emphasis on air bases), scenes related to national security and civil service, and war industries. Includes scenes of mountains, rivers, forests, other natural features, and towns. Also includes some historic sites and monuments.</bf:annotationBody>
+      <bf:summaryOf rdf:resource="http://example.org/11628622"/>
+   </bf:Summary>
+   <bf:Title rdf:about="http://example.org/11628622title5">
+      <bf:label>Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].</bf:label>
+      <bf:titleValue>Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/11628622person6">
+      <bf:label>Bransby, David</bf:label>
+      <bf:authorizedAccessPoint>Bransby, David</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Bransby, David</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person7">
+      <bf:label>Collins, Marjory, 1912-1985</bf:label>
+      <bf:authorizedAccessPoint>Collins, Marjory, 1912-1985</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Collins, Marjory, 1912-1985</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person8">
+      <bf:label>Collier, John, Jr., 1913-1992</bf:label>
+      <bf:authorizedAccessPoint>Collier, John, Jr., 1913-1992</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Collier, John, Jr., 1913-1992</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person9">
+      <bf:label>Delano, Jack</bf:label>
+      <bf:authorizedAccessPoint>Delano, Jack</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Delano, Jack</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person10">
+      <bf:label>Dixon, Royden</bf:label>
+      <bf:authorizedAccessPoint>Dixon, Royden</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Dixon, Royden</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person11">
+      <bf:label>Downey, Jack</bf:label>
+      <bf:authorizedAccessPoint>Downey, Jack</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Downey, Jack</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person12">
+      <bf:label>Feininger, Andreas, 1906-1999</bf:label>
+      <bf:authorizedAccessPoint>Feininger, Andreas, 1906-1999</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Feininger, Andreas, 1906-1999</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person13">
+      <bf:label>Hollem, Howard R.</bf:label>
+      <bf:authorizedAccessPoint>Hollem, Howard R.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hollem, Howard R.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person14">
+      <bf:label>Jacobs, Fenno, 1904-1975</bf:label>
+      <bf:authorizedAccessPoint>Jacobs, Fenno, 1904-1975</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Jacobs, Fenno, 1904-1975</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person15">
+      <bf:label>Lee, Russell, 1903-1986</bf:label>
+      <bf:authorizedAccessPoint>Lee, Russell, 1903-1986</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Lee, Russell, 1903-1986</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person16">
+      <bf:label>Liberman, Howard</bf:label>
+      <bf:authorizedAccessPoint>Liberman, Howard</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Liberman, Howard</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person17">
+      <bf:label>Palmer, Alfred T.</bf:label>
+      <bf:authorizedAccessPoint>Palmer, Alfred T.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Palmer, Alfred T.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person18">
+      <bf:label>Rittase, William M., 1894-1968</bf:label>
+      <bf:authorizedAccessPoint>Rittase, William M., 1894-1968</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Rittase, William M., 1894-1968</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person19">
+      <bf:label>Rosskam, Louise, 1910-2003</bf:label>
+      <bf:authorizedAccessPoint>Rosskam, Louise, 1910-2003</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Rosskam, Louise, 1910-2003</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person20">
+      <bf:label>Rothstein, Arthur, 1915-1985</bf:label>
+      <bf:authorizedAccessPoint>Rothstein, Arthur, 1915-1985</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Rothstein, Arthur, 1915-1985</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person21">
+      <bf:label>Rous, John</bf:label>
+      <bf:authorizedAccessPoint>Rous, John</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Rous, John</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person22">
+      <bf:label>Sherwood, Mark</bf:label>
+      <bf:authorizedAccessPoint>Sherwood, Mark</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Sherwood, Mark</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person23">
+      <bf:label>Siegel, Arthur S.</bf:label>
+      <bf:authorizedAccessPoint>Siegel, Arthur S.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Siegel, Arthur S.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person24">
+      <bf:label>Vachon, John, 1914-1975</bf:label>
+      <bf:authorizedAccessPoint>Vachon, John, 1914-1975</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Vachon, John, 1914-1975</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11628622person25">
+      <bf:label>Wolcott, Marion Post, 1910-1990</bf:label>
+      <bf:authorizedAccessPoint>Wolcott, Marion Post, 1910-1990</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Wolcott, Marion Post, 1910-1990</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Jurisdiction rdf:about="http://example.org/11628622jurisdiction26">
+      <bf:label>United States. Farm Security Administration.</bf:label>
+      <bf:authorizedAccessPoint>United States. Farm Security Administration.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Farm Security Administration.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Jurisdiction rdf:about="http://example.org/11628622jurisdiction27">
+      <bf:label>United States. Office of War Information.</bf:label>
+      <bf:authorizedAccessPoint>United States. Office of War Information.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Office of War Information.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Organization rdf:about="http://example.org/11628622organization31">
+      <bf:authorizedAccessPoint>Tennessee Valley Authority--1930-1940.</bf:authorizedAccessPoint>
+      <bf:label>Tennessee Valley Authority--1930-1940.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Tennessee Valley Authority--1930-1940.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource=""/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:CorporateName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Tennessee Valley Authority</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>Tennessee Valley Authority</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                  </madsrdf:elementList>
+               </madsrdf:CorporateName>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1940</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1940.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11628622topic32">
+      <bf:authorizedAccessPoint>Aeronautics--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Aeronautics--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Aeronautics--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Aeronautics</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Aeronautics</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic33">
+      <bf:authorizedAccessPoint>African Americans--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>African Americans--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>African Americans--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource=""/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>African Americans</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>African Americans</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic34">
+      <bf:authorizedAccessPoint>Agriculture--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Agriculture--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Agriculture--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Agriculture</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Agriculture</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic35">
+      <bf:authorizedAccessPoint>Assembly-line methods--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Assembly-line methods--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Assembly-line methods--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Assembly-line methods</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Assembly-line methods</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic36">
+      <bf:authorizedAccessPoint>Children--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Children--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Children--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Children</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Children</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic37">
+      <bf:authorizedAccessPoint>Civil engineering--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Civil engineering--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Civil engineering--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Civil engineering</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Civil engineering</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic38">
+      <bf:authorizedAccessPoint>Civil service--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Civil service--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Civil service--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Civil service</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Civil service</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic39">
+      <bf:authorizedAccessPoint>Country life--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Country life--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Country life--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Country life</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Country life</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic40">
+      <bf:authorizedAccessPoint>Depressions--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Depressions--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Depressions--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Depressions</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Depressions</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic41">
+      <bf:authorizedAccessPoint>Dwellings--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Dwellings--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Dwellings--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Dwellings</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Dwellings</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic42">
+      <bf:authorizedAccessPoint>Fairs--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Fairs--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Fairs--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Fairs</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Fairs</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic43">
+      <bf:authorizedAccessPoint>Farm relief--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Farm relief--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Farm relief--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Farm relief</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Farm relief</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic44">
+      <bf:authorizedAccessPoint>Farms--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Farms--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Farms--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Farms</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Farms</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic45">
+      <bf:authorizedAccessPoint>Forestry--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Forestry--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Forestry--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Forestry</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Forestry</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic46">
+      <bf:authorizedAccessPoint>Historic sites--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Historic sites--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Historic sites--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Historic sites</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Historic sites</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic47">
+      <bf:authorizedAccessPoint>Industrial facilities--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Industrial facilities--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Industrial facilities--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Industrial facilities</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Industrial facilities</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic48">
+      <bf:authorizedAccessPoint>Mining--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Mining--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Mining--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Mining</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Mining</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic49">
+      <bf:authorizedAccessPoint>Mountains--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Mountains--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Mountains--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Mountains</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Mountains</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic50">
+      <bf:authorizedAccessPoint>National security--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>National security--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>National security--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>National security</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>National security</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic51">
+      <bf:authorizedAccessPoint>Railroads--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Railroads--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Railroads--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Railroads</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Railroads</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic52">
+      <bf:authorizedAccessPoint>Shipping--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Shipping--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Shipping--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Shipping</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Shipping</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic53">
+      <bf:authorizedAccessPoint>Transportation--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Transportation--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Transportation--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Transportation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Transportation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic54">
+      <bf:authorizedAccessPoint>Women--Employment--United States--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Women--Employment--United States--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Women--Employment--United States--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource=""/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Women</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Women</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Employment</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Employment</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic55">
+      <bf:authorizedAccessPoint>World War, 1939-1945</bf:authorizedAccessPoint>
+      <bf:label>World War, 1939-1945</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
+            <madsrdf:authoritativeLabel>World War, 1939-1945</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic56">
+      <bf:authorizedAccessPoint>Dust Bowl Era, 1931-1939</bf:authorizedAccessPoint>
+      <bf:label>Dust Bowl Era, 1931-1939</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
+            <madsrdf:authoritativeLabel>Dust Bowl Era, 1931-1939</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic57">
+      <bf:authorizedAccessPoint>Landscape photographs--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Landscape photographs--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Landscape photographs--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Landscape photographs</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Landscape photographs</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic58">
+      <bf:authorizedAccessPoint>Film transparencies--Color--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Film transparencies--Color--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Film transparencies--Color--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Film transparencies</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Film transparencies</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Color</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Color</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11628622topic59">
+      <bf:authorizedAccessPoint>Slides--Color--1930-1950</bf:authorizedAccessPoint>
+      <bf:label>Slides--Color--1930-1950</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Slides--Color--1930-1950</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Slides</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Slides</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Color</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Color</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1930-1950</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1930-1950.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11628622title68">
+      <bf:label>Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].</bf:label>
+      <bf:titleValue>Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)</bf:titleValue>
+   </bf:Title>
+   <bf:Arrangement rdf:about="http://example.org/11628622arrangement94">
+      <bf:materialOrganization>Organized into two series (FSA and OWI): FSA has a series code beginning with the prefix LC-USF35; OWI has a series code beginning with prefix LC-USW36;</bf:materialOrganization>
+      <bf:materialArrangement>Each series is arranged by name of photographer, and subarranged by shooting assignment.</bf:materialArrangement>
+   </bf:Arrangement>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/findingAid/11628622.ttl
+++ b/spec/fixtures/loc/m2b-properties/findingAid/11628622.ttl
@@ -1,0 +1,1309 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix marcrelators: <http://id.loc.gov/vocabulary/relators/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11628622annotation63> a bf:Annotation;
+   bf:annotates <http://example.org/11628622>;
+   bf:changeDate "2015-06-26T08:24";
+   bf:derivedFrom <http://example.org/11628622.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/gihc>,
+     <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11628622helditem96> a bf:HeldItem;
+   bf:hdl <http://hdl.loc.gov/loc.pnp/pp.print>;
+   bf:heldBy "Library of Congress";
+   bf:holdingFor <http://example.org/11628622instance64>;
+   bf:label "";
+   bf:subLocation "Prints and Photographs Division" .
+
+<http://example.org/11628622instance33> a bf:Instance;
+   bf:hdl <http://hdl.loc.gov/loc.gdc/lcoa1.about>;
+   bf:instanceOf <http://example.org/11628622work29> .
+
+<http://example.org/11628622instance65> a bf:Instance,
+     bf:Electronic;
+   bf:hdl <http://hdl.loc.gov/loc.pnp/pp.fsac>;
+   bf:instanceOf <http://example.org/11628622>;
+   bf:label "Electronic Resource" .
+
+<http://example.org/11628622summary30> a bf:Summary;
+   bf:annotationAssertedBy <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:annotationBody "Documentary images of life and culture in the United States, Puerto Rico, and the U.S. Virgin Islands. Farm Security Administration images focus on rural areas, depicting farming, mining, forestry, migrant labor, children, and fairs. Includes particularly extensive coverage of Afro-Americans, but also includes whites, Hispanic Americans, and islanders. Office of War Information images cover civilian training during World War II, civil engineering (especially dam construction and operation of the Tennessee Valley Authority), factories and industrial labor, women working in the defense industry, transportation (particularly by railroad and by air), World War II mobilization, military facilities (with an emphasis on air bases), scenes related to national security and civil service, and war industries. Includes scenes of mountains, rivers, forests, other natural features, and towns. Also includes some historic sites and monuments.";
+   bf:label "Summary";
+   bf:summaryOf <http://example.org/11628622> .
+
+<http://example.org/11628622arrangement94> a bf:Arrangement;
+   bf:materialArrangement "Each series is arranged by name of photographer, and subarranged by shooting assignment.";
+   bf:materialOrganization "Organized into two series (FSA and OWI): FSA has a series code beginning with the prefix LC-USF35; OWI has a series code beginning with prefix LC-USW36;" .
+
+<http://example.org/11628622instance64> a bf:Instance,
+     bf:Electronic,
+     bf:Collection;
+   bf:accessCondition "Please use online digital copies instead of original material, following Division's preservation policy.";
+   bf:arrangement <http://example.org/11628622arrangement94>;
+   bf:dimensions "4 x 5 in. or smaller.";
+   bf:extent "1,616 transparencies (film and slides) :";
+   bf:formDesignation "graphic.";
+   bf:illustrationNote "color ;";
+   bf:immediateAcquisition "Transfer; U.S. Office of War Information; 1944.";
+   bf:instanceOf <http://example.org/11628622>;
+   bf:instanceTitle <http://example.org/11628622title68>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "93845501"
+   ];
+   bf:modeOfIssuance "monographic";
+   bf:note "Documentary images of life and culture in the United States, Puerto Rico, and the U.S. Virgin Islands. Farm Security Administration images focus on rural areas, depicting farming, mining, forestry, migrant labor, children, and fairs. Includes particularly extensive coverage of Afro-Americans, but also includes whites, Hispanic Americans, and islanders. Office of War Information images cover civilian training during World War II, civil engineering (especially dam construction and operation of the Tennessee Valley Authority), factories and industrial labor, women working in the defense industry, transportation (particularly by railroad and by air), World War II mobilization, military facilities (with an emphasis on air bases), scenes related to national security and civil service, and war industries. Includes scenes of mountains, rivers, forests, other natural features, and towns. Also includes some historic sites and monuments.",
+     "The U.S. Farm Security Administration (FSA) was created in the Department of Agriculture in 1937. The FSA and its predecessor, the Resettlement Administration (RA), were New Deal programs designed to assist poor farmers working in the Dust Bowl and during the Great Depression. The U.S. Office of War Information (OWI) was created in 1942 to be a U.S. government propaganda agency during World War II. The images created by these agencies during this period are among the earliest color film photographs used for documentary purpose. Many of the assignments covered in color were also covered in black and white.",
+     "Digitized images of all items in the collection and their associated identifying information are available through the Prints & Photographs Online Catalog,",
+     "Digitized images were also available through the Library of Congress American Memory Web site published in 1996 and closed in 2013; called: America from the Great Depression to World War II: color photographs from the FSA-OWI, 1939-1945.",
+     "B&w reference copy prints are LOT 11671 and LOT 12002.",
+     "Collection title devised by Library staff.",
+     "Photographers are: David Bransby (1942), John Collier (1942-1943), Marjory Collins (1943), Jack Delano (1940-1943), Royden Dixon (1941-1942), Jack Downey (1944), Andreas Feininger (1942), Howard R. Hollem (ca. 1941-1945), Fenno Jacobs (1942), Russell Lee (1940-1942), Howard Liberman (1942), Alfred T. Palmer (1941-1943), William M. Rittase (1942), Louise Rosskam (1941-1942), Arthur Rothstein (1942), John Rous (1941), Mark Sherwood (1942), Arthur S. Siegel (1942), John Vachon (1939-1942), and Marion Post Wolcott (1939-1941).",
+     "Includes 550 35mm slides; the other transparencies are larger format: 2 1/2 x 2 1/2, 3x4, and 4x5 inches. The type of film is Kodachrome.",
+     "Published in: Bound for glory: America in color, 1939-43 / Essay by Paul Hendrickson. New York : H.N. Abrams, 2004.";
+   bf:providerStatement "1939-1944.";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "1939-1944"
+   ];
+   bf:soundContent "Unknown";
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "11628622"
+   ];
+   bf:titleStatement "Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)" .
+
+<http://example.org/11628622jurisdiction26> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "United States. Farm Security Administration.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Farm Security Administration."
+   ];
+   bf:label "United States. Farm Security Administration." .
+
+<http://example.org/11628622jurisdiction27> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "United States. Office of War Information.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Office of War Information."
+   ];
+   bf:label "United States. Office of War Information." .
+
+<http://example.org/11628622organization31> a bf:Organization;
+   bf:authorizedAccessPoint "Tennessee Valley Authority--1930-1940.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Tennessee Valley Authority--1930-1940.";
+     mads:componentList ([
+         a mads:CorporateName,
+           mads:Authority;
+         mads:authoritativeLabel "Tennessee Valley Authority";
+         mads:elementList ([
+             a mads:NameElement;
+             mads:elementValue "Tennessee Valley Authority"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1940";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1940."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <>
+   ];
+   bf:label "Tennessee Valley Authority--1930-1940." .
+
+<http://example.org/11628622person10> a bf:Person;
+   bf:authorizedAccessPoint "Dixon, Royden";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Dixon, Royden"
+   ];
+   bf:label "Dixon, Royden" .
+
+<http://example.org/11628622person11> a bf:Person;
+   bf:authorizedAccessPoint "Downey, Jack";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Downey, Jack"
+   ];
+   bf:label "Downey, Jack" .
+
+<http://example.org/11628622person12> a bf:Person;
+   bf:authorizedAccessPoint "Feininger, Andreas, 1906-1999";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Feininger, Andreas, 1906-1999"
+   ];
+   bf:label "Feininger, Andreas, 1906-1999" .
+
+<http://example.org/11628622person13> a bf:Person;
+   bf:authorizedAccessPoint "Hollem, Howard R.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hollem, Howard R."
+   ];
+   bf:label "Hollem, Howard R." .
+
+<http://example.org/11628622person14> a bf:Person;
+   bf:authorizedAccessPoint "Jacobs, Fenno, 1904-1975";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Jacobs, Fenno, 1904-1975"
+   ];
+   bf:label "Jacobs, Fenno, 1904-1975" .
+
+<http://example.org/11628622person15> a bf:Person;
+   bf:authorizedAccessPoint "Lee, Russell, 1903-1986";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Lee, Russell, 1903-1986"
+   ];
+   bf:label "Lee, Russell, 1903-1986" .
+
+<http://example.org/11628622person16> a bf:Person;
+   bf:authorizedAccessPoint "Liberman, Howard";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Liberman, Howard"
+   ];
+   bf:label "Liberman, Howard" .
+
+<http://example.org/11628622person17> a bf:Person;
+   bf:authorizedAccessPoint "Palmer, Alfred T.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Palmer, Alfred T."
+   ];
+   bf:label "Palmer, Alfred T." .
+
+<http://example.org/11628622person18> a bf:Person;
+   bf:authorizedAccessPoint "Rittase, William M., 1894-1968";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Rittase, William M., 1894-1968"
+   ];
+   bf:label "Rittase, William M., 1894-1968" .
+
+<http://example.org/11628622person19> a bf:Person;
+   bf:authorizedAccessPoint "Rosskam, Louise, 1910-2003";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Rosskam, Louise, 1910-2003"
+   ];
+   bf:label "Rosskam, Louise, 1910-2003" .
+
+<http://example.org/11628622person20> a bf:Person;
+   bf:authorizedAccessPoint "Rothstein, Arthur, 1915-1985";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Rothstein, Arthur, 1915-1985"
+   ];
+   bf:label "Rothstein, Arthur, 1915-1985" .
+
+<http://example.org/11628622person21> a bf:Person;
+   bf:authorizedAccessPoint "Rous, John";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Rous, John"
+   ];
+   bf:label "Rous, John" .
+
+<http://example.org/11628622person22> a bf:Person;
+   bf:authorizedAccessPoint "Sherwood, Mark";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Sherwood, Mark"
+   ];
+   bf:label "Sherwood, Mark" .
+
+<http://example.org/11628622person23> a bf:Person;
+   bf:authorizedAccessPoint "Siegel, Arthur S.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Siegel, Arthur S."
+   ];
+   bf:label "Siegel, Arthur S." .
+
+<http://example.org/11628622person24> a bf:Person;
+   bf:authorizedAccessPoint "Vachon, John, 1914-1975";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Vachon, John, 1914-1975"
+   ];
+   bf:label "Vachon, John, 1914-1975" .
+
+<http://example.org/11628622person25> a bf:Person;
+   bf:authorizedAccessPoint "Wolcott, Marion Post, 1910-1990";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Wolcott, Marion Post, 1910-1990"
+   ];
+   bf:label "Wolcott, Marion Post, 1910-1990" .
+
+<http://example.org/11628622person6> a bf:Person;
+   bf:authorizedAccessPoint "Bransby, David";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Bransby, David"
+   ];
+   bf:label "Bransby, David" .
+
+<http://example.org/11628622person7> a bf:Person;
+   bf:authorizedAccessPoint "Collins, Marjory, 1912-1985";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Collins, Marjory, 1912-1985"
+   ];
+   bf:label "Collins, Marjory, 1912-1985" .
+
+<http://example.org/11628622person8> a bf:Person;
+   bf:authorizedAccessPoint "Collier, John, Jr., 1913-1992";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Collier, John, Jr., 1913-1992"
+   ];
+   bf:label "Collier, John, Jr., 1913-1992" .
+
+<http://example.org/11628622person9> a bf:Person;
+   bf:authorizedAccessPoint "Delano, Jack";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Delano, Jack"
+   ];
+   bf:label "Delano, Jack" .
+
+<http://example.org/11628622title5> a bf:Title;
+   bf:label "Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].";
+   bf:titleValue "Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)" .
+
+<http://example.org/11628622title68> a bf:Title;
+   bf:label "Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].";
+   bf:titleValue "Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)" .
+
+<http://example.org/11628622topic32> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Aeronautics--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Aeronautics--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Aeronautics";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Aeronautics"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Aeronautics--United States--1930-1950" .
+
+<http://example.org/11628622topic33> a bf:Topic;
+   bf:authorizedAccessPoint "African Americans--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "African Americans--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "African Americans";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "African Americans"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <>
+   ];
+   bf:label "African Americans--1930-1950" .
+
+<http://example.org/11628622topic34> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Agriculture--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Agriculture--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Agriculture";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Agriculture"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Agriculture--United States--1930-1950" .
+
+<http://example.org/11628622topic35> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Assembly-line methods--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Assembly-line methods--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Assembly-line methods";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Assembly-line methods"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Assembly-line methods--United States--1930-1950" .
+
+<http://example.org/11628622topic36> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Children--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Children--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Children";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Children"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Children--United States--1930-1950" .
+
+<http://example.org/11628622topic37> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Civil engineering--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Civil engineering--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Civil engineering";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Civil engineering"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Civil engineering--United States--1930-1950" .
+
+<http://example.org/11628622topic38> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Civil service--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Civil service--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Civil service";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Civil service"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Civil service--United States--1930-1950" .
+
+<http://example.org/11628622topic39> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Country life--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Country life--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Country life";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Country life"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Country life--United States--1930-1950" .
+
+<http://example.org/11628622topic40> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Depressions--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Depressions--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Depressions";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Depressions"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Depressions--United States--1930-1950" .
+
+<http://example.org/11628622topic41> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Dwellings--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Dwellings--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Dwellings";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Dwellings"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Dwellings--United States--1930-1950" .
+
+<http://example.org/11628622topic42> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Fairs--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Fairs--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Fairs";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Fairs"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Fairs--United States--1930-1950" .
+
+<http://example.org/11628622topic43> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Farm relief--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Farm relief--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Farm relief";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Farm relief"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Farm relief--United States--1930-1950" .
+
+<http://example.org/11628622topic44> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Farms--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Farms--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Farms";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Farms"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Farms--United States--1930-1950" .
+
+<http://example.org/11628622topic45> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Forestry--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Forestry--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Forestry";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Forestry"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Forestry--United States--1930-1950" .
+
+<http://example.org/11628622topic46> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Historic sites--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Historic sites--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Historic sites";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Historic sites"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Historic sites--United States--1930-1950" .
+
+<http://example.org/11628622topic47> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Industrial facilities--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Industrial facilities--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Industrial facilities";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Industrial facilities"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Industrial facilities--United States--1930-1950" .
+
+<http://example.org/11628622topic48> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Mining--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Mining--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Mining";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Mining"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Mining--United States--1930-1950" .
+
+<http://example.org/11628622topic49> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Mountains--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Mountains--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Mountains";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Mountains"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Mountains--United States--1930-1950" .
+
+<http://example.org/11628622topic50> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "National security--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "National security--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "National security";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "National security"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "National security--United States--1930-1950" .
+
+<http://example.org/11628622topic51> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Railroads--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Railroads--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Railroads";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Railroads"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Railroads--United States--1930-1950" .
+
+<http://example.org/11628622topic52> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Shipping--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Shipping--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Shipping";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Shipping"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Shipping--United States--1930-1950" .
+
+<http://example.org/11628622topic53> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Transportation--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Transportation--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Transportation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Transportation"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Transportation--United States--1930-1950" .
+
+<http://example.org/11628622topic54> a bf:Topic;
+   bf:authorizedAccessPoint "Women--Employment--United States--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Women--Employment--United States--1930-1950";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Women";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Women"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Employment";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Employment"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <>
+   ];
+   bf:label "Women--Employment--United States--1930-1950" .
+
+<http://example.org/11628622topic55> a bf:Topic;
+   bf:authorizedAccessPoint "World War, 1939-1945";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:Topic;
+     mads:authoritativeLabel "World War, 1939-1945";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "World War, 1939-1945" .
+
+<http://example.org/11628622topic56> a bf:Topic;
+   bf:authorizedAccessPoint "Dust Bowl Era, 1931-1939";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:Topic;
+     mads:authoritativeLabel "Dust Bowl Era, 1931-1939";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Dust Bowl Era, 1931-1939" .
+
+<http://example.org/11628622topic57> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Landscape photographs--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Landscape photographs--1930-1950";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Landscape photographs";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Landscape photographs"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Landscape photographs--1930-1950" .
+
+<http://example.org/11628622topic58> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Film transparencies--Color--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Film transparencies--Color--1930-1950";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Film transparencies";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Film transparencies"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Color";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Color"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Film transparencies--Color--1930-1950" .
+
+<http://example.org/11628622topic59> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Slides--Color--1930-1950";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Slides--Color--1930-1950";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Slides";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Slides"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Color";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Color"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1930-1950";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1930-1950."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Slides--Color--1930-1950" .
+
+<http://example.org/11628622work61> a bf:Work;
+   bf:authorizedAccessPoint "America from the great depression to World War II: color photographs from the FSA-OWI, 1939-1945.";
+   bf:title "America from the great depression to World War II: color photographs from the FSA-OWI, 1939-1945." .
+
+<http://example.org/11628622work29> a bf:Work;
+   bf:authorizedAccessPoint "A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See";
+   bf:title "A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See" .
+
+<http://example.org/11628622> a bf:Work,
+     bf:StillImage;
+   bf:authorizedAccessPoint "Bransby, David Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress) [graphic].Farm Security Administration - Office of War Information color slides and transparencies collection (Library of Congress)",
+     "bransbydavidcollinsmarjory19121985collierjohnjr19131992delanojackdixonroydendowneyjackfeiningerandreas19061999hollemhowardrjacobsfenno19041975leerussell19031986libermanhowardpalmeralfredtrittasewilliamm18941968rosskamlouise19102003rothsteinarthur19151985rousjohnsherwoodmarksiegelarthursvachonjohn19141975wolcottmarionpost19101990unitedstatesfarmsecurityadministrationunitedstatesofficeofwarinformationfarmsecurityadministrationofficeofwarinformationcolorslidesandtransparenciescollectionlibraryofcongressengworkstillimage"@x-bf-hash;
+   bf:contributor <http://example.org/11628622jurisdiction26>,
+     <http://example.org/11628622jurisdiction27>;
+   bf:index <http://example.org/11628622work29>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:relatedWork <http://example.org/11628622work61>;
+   bf:subject <http://example.org/11628622organization31>,
+     <http://example.org/11628622topic32>,
+     <http://example.org/11628622topic33>,
+     <http://example.org/11628622topic34>,
+     <http://example.org/11628622topic35>,
+     <http://example.org/11628622topic36>,
+     <http://example.org/11628622topic37>,
+     <http://example.org/11628622topic38>,
+     <http://example.org/11628622topic39>,
+     <http://example.org/11628622topic40>,
+     <http://example.org/11628622topic41>,
+     <http://example.org/11628622topic42>,
+     <http://example.org/11628622topic43>,
+     <http://example.org/11628622topic44>,
+     <http://example.org/11628622topic45>,
+     <http://example.org/11628622topic46>,
+     <http://example.org/11628622topic47>,
+     <http://example.org/11628622topic48>,
+     <http://example.org/11628622topic49>,
+     <http://example.org/11628622topic50>,
+     <http://example.org/11628622topic51>,
+     <http://example.org/11628622topic52>,
+     <http://example.org/11628622topic53>,
+     <http://example.org/11628622topic54>,
+     <http://example.org/11628622topic55>,
+     <http://example.org/11628622topic56>,
+     <http://example.org/11628622topic57>,
+     <http://example.org/11628622topic58>,
+     <http://example.org/11628622topic59>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us>;
+   bf:workTitle <http://example.org/11628622title5>;
+   marcrelators:pht <http://example.org/11628622person6>,
+     <http://example.org/11628622person7>,
+     <http://example.org/11628622person8>,
+     <http://example.org/11628622person9>,
+     <http://example.org/11628622person10>,
+     <http://example.org/11628622person11>,
+     <http://example.org/11628622person12>,
+     <http://example.org/11628622person13>,
+     <http://example.org/11628622person14>,
+     <http://example.org/11628622person15>,
+     <http://example.org/11628622person16>,
+     <http://example.org/11628622person17>,
+     <http://example.org/11628622person18>,
+     <http://example.org/11628622person19>,
+     <http://example.org/11628622person20>,
+     <http://example.org/11628622person21>,
+     <http://example.org/11628622person22>,
+     <http://example.org/11628622person23>,
+     <http://example.org/11628622person24>,
+     <http://example.org/11628622person25> .

--- a/spec/fixtures/loc/m2b-properties/findingAidNote/12006847.marcxml
+++ b/spec/fixtures/loc/m2b-properties/findingAidNote/12006847.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02026ckd a22004577a 4500</leader>
   <controlfield tag="001">12006847</controlfield>
   <controlfield tag="005">20091027173425.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="o">ppsd</subfield>
     <subfield code="v">obj.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12006847</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/formDesignation/3653947.marcxml
+++ b/spec/fixtures/loc/m2b-properties/formDesignation/3653947.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00627cam a2200181 i 4500</leader>
   <controlfield tag="001">3653947</controlfield>
   <controlfield tag="005">20130418064448.0</controlfield>
@@ -54,4 +54,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3653947</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/frequency/11485330.marcxml
+++ b/spec/fixtures/loc/m2b-properties/frequency/11485330.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02015cas a2200529 a 4500</leader>
   <controlfield tag="001">11485330</controlfield>
   <controlfield tag="005">20150822155846.0</controlfield>
@@ -173,4 +173,4 @@
     <subfield code="b">SER</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11485330</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/frequencyNote/12800873.marcxml
+++ b/spec/fixtures/loc/m2b-properties/frequencyNote/12800873.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01794cas a2200433 a 4500</leader>
   <controlfield tag="001">12800873</controlfield>
   <controlfield tag="005">20130323160419.0</controlfield>
@@ -135,4 +135,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">eserial 200406</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12800873</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/generationProcess/11176633.marcxml
+++ b/spec/fixtures/loc/m2b-properties/generationProcess/11176633.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04806cas a2200913 a 4500</leader>
   <controlfield tag="001">11176633</controlfield>
   <controlfield tag="005">20140405155747.0</controlfield>
@@ -441,4 +441,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11176633</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/geographicCoverageNote/5565434.marcxml
+++ b/spec/fixtures/loc/m2b-properties/geographicCoverageNote/5565434.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02976nem a2200577 a 4500</leader>
   <controlfield tag="001">5565434</controlfield>
   <controlfield tag="005">19981208152057.5</controlfield>
@@ -164,4 +164,4 @@
     <subfield code="m">CD</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5565434</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/graphicScaleNote/5403112.marcxml
+++ b/spec/fixtures/loc/m2b-properties/graphicScaleNote/5403112.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00773cem a2200265   4500</leader>
   <controlfield tag="001">5403112</controlfield>
   <controlfield tag="005">19951107130659.3</controlfield>
@@ -71,4 +71,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5403112</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hasAnnotation/15599751.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hasAnnotation/15599751.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01787cam a22004217a 4500</leader>
   <controlfield tag="001">15599751</controlfield>
   <controlfield tag="005">20120719124759.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="i">.R67 2009</subfield>
     <subfield code="t">Copy 1</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15599751</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hasAuthority/11187857.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hasAuthority/11187857.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02911cas a2200685 a 4500</leader>
   <controlfield tag="001">11187857</controlfield>
   <controlfield tag="005">20140912075312.0</controlfield>
@@ -238,4 +238,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11187857</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hasInstance/630296.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hasInstance/630296.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00850nam a22002411i 4500</leader>
   <controlfield tag="001">630296</controlfield>
   <controlfield tag="005">19960801113358.3</controlfield>

--- a/spec/fixtures/loc/m2b-properties/hasPart/14978856.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hasPart/14978856.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>06510ckc a22006857a 4500</leader>
   <controlfield tag="001">14978856</controlfield>
   <controlfield tag="005">20130603103814.0</controlfield>
@@ -228,4 +228,4 @@
     <subfield code="t">Putnam</subfield>
     <subfield code="w">(DLC)    2007567098</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14978856</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hasPart/14978856.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/hasPart/14978856.rdfxml
@@ -1,0 +1,996 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/14978856">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <rdf:type rdf:resource="http://bibframe.org/vocab/StillImage"/>
+      <bf:authorizedAccessPoint>Carpenter, W. M. (William Montelle), 1866-1931. [Carpenter Kipling scrapbooks] [graphic].[Carpenter Kipling scrapbooks]</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/14978856title6"/>
+      <bf:creator rdf:resource="http://example.org/14978856person7"/>
+      <bf:contributor rdf:resource="http://example.org/14978856person8"/>
+      <bf:contributor rdf:resource="http://example.org/14978856organization9"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:findingAidNote>Finding aid consists of detailed list of contents of each volume compiled by Library staff laid in each box.</bf:findingAidNote>
+      <bf:subject rdf:resource="http://example.org/14978856person13"/>
+      <bf:subject rdf:resource="http://example.org/14978856person14"/>
+      <bf:subject rdf:resource="http://example.org/14978856person15"/>
+      <bf:subject rdf:resource="http://example.org/14978856person16"/>
+      <bf:subject rdf:resource="http://example.org/14978856person17"/>
+      <bf:subject rdf:resource="http://example.org/14978856person18"/>
+      <bf:subject rdf:resource="http://example.org/14978856person19"/>
+      <bf:subject rdf:resource="http://example.org/14978856person20"/>
+      <bf:subject rdf:resource="http://example.org/14978856person21"/>
+      <bf:subject rdf:resource="http://example.org/14978856person22"/>
+      <bf:subject rdf:resource="http://example.org/14978856person23"/>
+      <bf:subject rdf:resource="http://example.org/14978856person24"/>
+      <bf:subject rdf:resource="http://example.org/14978856person25"/>
+      <bf:subject rdf:resource="http://example.org/14978856organization26"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic27"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic28"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic29"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic30"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic31"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic32"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic33"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic34"/>
+      <bf:subject rdf:resource="http://example.org/14978856topic35"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/e-uk-en"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/Z8465"/>
+      <bf:relatedResource rdf:resource="http://example.org/14978856work39"/>
+      <bf:relatedResource rdf:resource="http://example.org/14978856work40"/>
+      <bf:hasPart rdf:resource="http://example.org/14978856work41"/>
+      <bf:hasPart rdf:resource="http://example.org/14978856work42"/>
+      <bf:hasPart rdf:resource="http://example.org/14978856work43"/>
+      <bf:hasPart rdf:resource="http://example.org/14978856work44"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">carpenterlucilerussellkiplingrudyard18651936kiplingrudyard18651936kiplingrudyard18651936carpenterkiplingcollectionlibraryofcongresscarpenterwmwilliammontelle18661931carpenterkiplingscrapbooksengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work39">
+      <bf:title>Civil &amp; military gazette (Lahore, Pakistan)</bf:title>
+      <bf:authorizedAccessPoint>Civil &amp; military gazette (Lahore, Pakistan)</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work40">
+      <bf:title>From sea to sea.</bf:title>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936. From sea to sea.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/14978856person44"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work41">
+      <bf:title>Putnam.</bf:title>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936. Putnam.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/14978856person45"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work42">
+      <bf:title>To the address of W.W.H.</bf:title>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936. To the address of W.W.H.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/14978856person46"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work43">
+      <bf:title>Putnam</bf:title>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936. Putnam</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2007567098"/>
+      <bf:contributor rdf:resource="http://example.org/14978856agent48"/>
+      <bf:partOf rdf:resource="http://example.org/14978856"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14978856work44">
+      <bf:title>Putnam</bf:title>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936. Putnam</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2007567098"/>
+      <bf:contributor rdf:resource="http://example.org/14978856agent49"/>
+      <bf:partOf rdf:resource="http://example.org/14978856"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/14978856instance47">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Collection"/>
+      <bf:instanceTitle rdf:resource="http://example.org/14978856title50"/>
+      <bf:titleVariation rdf:resource="http://example.org/14978856title51"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:copyrightDate>[1881-1945]</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>monographic</bf:modeOfIssuance>
+      <bf:extent>7 scrapbooks (ca. 520 items) ;</bf:extent>
+      <bf:dimensions>30 x 26 cm. and 31 x 27 cm.</bf:dimensions>
+      <bf:titleStatement>Carpenter Kipling scrapbooks</bf:titleStatement>
+      <bf:formDesignation>graphic.</bf:formDesignation>
+      <bf:providerStatement>1881-1945</bf:providerStatement>
+      <bf:accessCondition>Restrictions: Poor condition of many of the original clippings within the scrapbooks.</bf:accessCondition>
+      <bf:contentsNote>Vol. 1. Proof copy of Kipling's poem "To the address of W.W.H." ; Carbon manuscript copy of fragment of essay by Rudyard Kipling written during the "From Sea to Sea" trip, 1889 ; Photostat copies of "Manuscript from Sea to Sea letters India through Japan, 19 Turnovers", 1889 (originals in Henry E. Huntington Library). Photographs and negatives. Typewritten transcripts of Kipling correspondence to James Conland, Charles Warren Stoddard and others transcribed by Carpenter. ALS from Sydney Lowe to W.M. Carpenter dated May 17, 1916 -- v. 2. Kipling's writings during the "American Period" / W.M. Carpenter. Kipling Society correspondence with Mr. Carpenter. ALS from L.C. Dunsterville to W.M. Carpenter, August 28, 1931. TLS to W.M. Carpenter from Henry H. Conland, February 20, 1928 -- v. 3. Kipling and his college / W.M. Carpenter. Group photograph of Kipling and his schoolmates, ca. 1881. TLS to W.M. Carpenter from Thomas McLean, schoolmate of Kipling from United Services College. On Balfour, Guthrie &amp; Co. letterhead, Tacoma, Washington, dated June 10, 1931. Newspaper clippings from the Civil and Military Gazette, 1888 containing articles by Kipling. Handwritten notes from Mrs. Edmonia Taylor Hill. R.K.'s Allahabad home ; Kipling in San Francisco ; Oregon ; The Kipling creed ; Kipling items copied from newspapers-by W.M.C. ; various comments on individual Kipling titles / W.M. Carpenter. Putnam / Rudyard Kipling. "Jungle Dinner Feb. 21, 1899" / Mrs. Hill. TLS to W.M. Carpenter from F.W. Childs, August 9, 1928 and October 11, 1928. Transcripts of letters from W.D. Howells to Aurelia Howells and from Kipling to W.D. Howells. Transcripts of typewritten copies of Last will and testament of ... Rudyard Kipling and Last will and testament of ... Caroline Kipling, widow -- v. 4. William M. Carpenter typescripts relating to "The Friend" period in South Africa. Typescript: "Copy of letter from Mrs. Flora V. Livingston to W.M. Carpenter about Kipling's contributions to 'The Friend'". Typescript: "A Burgher of the Free State" / W.M. Carpenter with handwritten note initialed on first page by L.H. Chandler -- v. 5. Clippings: India, South Africa, America -- v. 6. Clippings: Reviews, Criticisms, Interviews, Addresses, Tributes, Miscellaneous items -- v. 7. Clippings: Kipling's life, homes, family. Vermont, World War I. School days. Honors. Religion-Rosicrucians. Illness. Death. Reviews &amp; criticisms of his writings. Mrs. Kipling's death. Disposal of estate. Lord Birkenhead's biography of R.K. banned by Elsie Kipling Bambridge.</bf:contentsNote>
+      <bf:note>Scrapbooks include various typescript drafts written by William M. Carpenter about Rudyard Kipling's life and document the collection of Rudyard Kipling materials acquired by Carpenter. Also includes numerous ephemeral items relating to the life of Kipling.</bf:note>
+      <bf:note>Includes four scrapbooks of manuscripts, typescripts, correspondence, transcripts of correspondence, photostat copies of manuscripts, notes, clippings, photographs and other ephemera removed from original binders. Also includes three original scrapbook volumes containing newspaper and magazine clippings from various sources. Two additional volumes containing original correspondence of Rudyard Kipling had been rehoused into one container and are now cataloged under [Carpenter Kipling Collection miscellaneous letters] on lccn 2007581629.</bf:note>
+      <bf:note>Title devised by Library staff.</bf:note>
+      <bf:note>Compiled by Mr. and Mrs. William M. Carpenter. Gift of Mrs. William Montelle Carpenter, 1955.</bf:note>
+      <bf:note>LC collection rehoused in 4 boxes: 27 x 40 x 13 cm. and 3 boxes: 37 x 29 x 8 cm. Original scrapbook binders are included at the back of each box.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2007581632</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:instanceOf rdf:resource="http://example.org/14978856"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/14978856annotation46">
+      <bf:derivedFrom rdf:resource="http://example.org/14978856.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/gihc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-06-03T10:38</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/14978856"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/14978856helditem68">
+      <bf:label>Z8465 .C373 1881</bf:label>
+      <bf:shelfMarkLcc>Z8465 .C373 1881</bf:shelfMarkLcc>
+      <bf:custodialHistory>Compiled by Mr. and Mrs. William M. Carpenter. Gift of Mrs. William Montelle Carpenter, 1955.</bf:custodialHistory>
+      <bf:holdingFor rdf:resource="http://example.org/14978856instance47"/>
+   </bf:HeldItem>
+   <bf:Summary rdf:about="http://example.org/14978856summary12">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Summary"/>
+      <bf:label>Summary</bf:label>
+      <bf:annotationAssertedBy rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:annotationBody>Scrapbooks include various typescript drafts written by William M. Carpenter about Rudyard Kipling's life and document the collection of Rudyard Kipling materials acquired by Carpenter. Also includes numerous ephemeral items relating to the life of Kipling.</bf:annotationBody>
+      <bf:summaryOf rdf:resource="http://example.org/14978856"/>
+   </bf:Summary>
+   <bf:Title rdf:about="http://example.org/14978856title6">
+      <bf:label>[Carpenter Kipling scrapbooks] [graphic].</bf:label>
+      <bf:titleValue>[Carpenter Kipling scrapbooks]</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/14978856person7">
+      <bf:label>Carpenter, W. M. (William Montelle), 1866-1931.</bf:label>
+      <bf:authorizedAccessPoint>Carpenter, W. M. (William Montelle), 1866-1931.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Carpenter, W. M. (William Montelle), 1866-1931.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person8">
+      <bf:label>Carpenter, Lucile Russell.</bf:label>
+      <bf:authorizedAccessPoint>Carpenter, Lucile Russell.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Carpenter, Lucile Russell.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Organization rdf:about="http://example.org/14978856organization9">
+      <bf:label>Carpenter Kipling Collection (Library of Congress)</bf:label>
+      <bf:authorizedAccessPoint>Carpenter Kipling Collection (Library of Congress)</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Carpenter Kipling Collection (Library of Congress)</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Person rdf:about="http://example.org/14978856person13">
+      <bf:authorizedAccessPoint>Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts.</bf:authorizedAccessPoint>
+      <bf:label>Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Carpenter, W. M. (William Montelle), 1866-1931</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Carpenter, W. M.</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>(William Montelle),</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1866-1931</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Manuscripts</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Manuscripts.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person14">
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#PersonalName"/>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person15">
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936--Manuscripts.</bf:authorizedAccessPoint>
+      <bf:label>Kipling, Rudyard, 1865-1936--Manuscripts.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936--Manuscripts.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Kipling, Rudyard,</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1865-1936</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Manuscripts</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Manuscripts.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person16">
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles.</bf:authorizedAccessPoint>
+      <bf:label>Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Kipling, Rudyard,</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1865-1936</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Manuscripts</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Manuscripts</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Facsimiles</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Facsimiles.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person17">
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936--Miscellanea.</bf:authorizedAccessPoint>
+      <bf:label>Kipling, Rudyard, 1865-1936--Miscellanea.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936--Miscellanea.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Kipling, Rudyard,</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1865-1936</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Miscellanea</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Miscellanea.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person18">
+      <bf:authorizedAccessPoint>Carpenter, W. M. (William Montelle), 1866-1931--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Carpenter, W. M. (William Montelle), 1866-1931--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Carpenter, W. M. (William Montelle), 1866-1931--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Carpenter, W. M. (William Montelle), 1866-1931</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Carpenter, W. M.</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>(William Montelle),</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1866-1931</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person19">
+      <bf:authorizedAccessPoint>Carpenter, Lucile Russell--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Carpenter, Lucile Russell--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Carpenter, Lucile Russell--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Carpenter, Lucile Russell</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Carpenter, Lucile Russell</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person20">
+      <bf:authorizedAccessPoint>Childs, F. W. (Frederick W.), 1849-1946--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Childs, F. W. (Frederick W.), 1849-1946--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Childs, F. W. (Frederick W.), 1849-1946--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Childs, F. W. (Frederick W.), 1849-1946</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Childs, F. W.</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>(Frederick W.),</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1849-1946</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person21">
+      <bf:authorizedAccessPoint>Conland, Henry H., 1882---Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Conland, Henry H., 1882---Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Conland, Henry H., 1882---Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Conland, Henry H., 1882-</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Conland, Henry H.,</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1882-</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person22">
+      <bf:authorizedAccessPoint>Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Dunsterville, L. C. (Lionel Charles), 1865-1946</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Dunsterville, L. C.</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>(Lionel Charles),</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1865-1946</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person23">
+      <bf:authorizedAccessPoint>Hill, Edmonia Taylor, -1952--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Hill, Edmonia Taylor, -1952--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Hill, Edmonia Taylor, -1952--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Hill, Edmonia Taylor, -1952</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Hill, Edmonia Taylor,</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>-1952</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person24">
+      <bf:authorizedAccessPoint>Lowe, Sidney--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Lowe, Sidney--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Lowe, Sidney--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Lowe, Sidney</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Lowe, Sidney</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person25">
+      <bf:authorizedAccessPoint>McLean, Thomas--Correspondence.</bf:authorizedAccessPoint>
+      <bf:label>McLean, Thomas--Correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>McLean, Thomas--Correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>McLean, Thomas</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>McLean, Thomas</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Organization rdf:about="http://example.org/14978856organization26">
+      <bf:authorizedAccessPoint>Kipling Society--Records and correspondence.</bf:authorizedAccessPoint>
+      <bf:label>Kipling Society--Records and correspondence.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Kipling Society--Records and correspondence.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:CorporateName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Kipling Society</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>Kipling Society</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                  </madsrdf:elementList>
+               </madsrdf:CorporateName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Records and correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Records and correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/14978856topic27">
+      <bf:authorizedAccessPoint>Authors, English--19th century--Biography</bf:authorizedAccessPoint>
+      <bf:label>Authors, English--19th century--Biography</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Authors, English--19th century--Biography</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Authors, English</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Authors, English</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>19th century</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>19th century</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Biography</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Biography.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic28">
+      <bf:authorizedAccessPoint>Authors, English--20th century--Biography</bf:authorizedAccessPoint>
+      <bf:label>Authors, English--20th century--Biography</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Authors, English--20th century--Biography</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Authors, English</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Authors, English</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>20th century</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>20th century</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Biography</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Biography.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic29">
+      <bf:authorizedAccessPoint>Book collectors--United States--Correspondence</bf:authorizedAccessPoint>
+      <bf:label>Book collectors--United States--Correspondence</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Book collectors--United States--Correspondence</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Book collectors</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Book collectors</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Correspondence</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Correspondence.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic30">
+      <bf:authorizedAccessPoint>Scrapbooks--1920-1960</bf:authorizedAccessPoint>
+      <bf:label>Scrapbooks--1920-1960</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Scrapbooks--1920-1960</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Scrapbooks</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Scrapbooks</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1920-1960</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1920-1960.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic31">
+      <bf:authorizedAccessPoint>Photographic prints--1880-1890</bf:authorizedAccessPoint>
+      <bf:label>Photographic prints--1880-1890</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Photographic prints--1880-1890</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Photographic prints</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Photographic prints</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1890</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1890.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic32">
+      <bf:authorizedAccessPoint>Photographic prints--1920-1930</bf:authorizedAccessPoint>
+      <bf:label>Photographic prints--1920-1930</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Photographic prints--1920-1930</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Photographic prints</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Photographic prints</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1920-1930</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1920-1930.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic33">
+      <bf:authorizedAccessPoint>Portrait photographs--1920-1930</bf:authorizedAccessPoint>
+      <bf:label>Portrait photographs--1920-1930</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Portrait photographs--1920-1930</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Portrait photographs</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Portrait photographs</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1920-1930</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1920-1930.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic34">
+      <bf:authorizedAccessPoint>Clippings--1920-1960</bf:authorizedAccessPoint>
+      <bf:label>Clippings--1920-1960</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Clippings--1920-1960</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Clippings</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Clippings</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1920-1960</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1920-1960.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/14978856topic35">
+      <bf:authorizedAccessPoint>Stats--1920-1930</bf:authorizedAccessPoint>
+      <bf:label>Stats--1920-1930</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Stats--1920-1930</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Stats</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Stats</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1920-1930</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1920-1930.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Person rdf:about="http://example.org/14978856person44">
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person45">
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14978856person46">
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Agent rdf:about="http://example.org/14978856agent48">
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/14978856agent49">
+      <bf:label>Kipling, Rudyard, 1865-1936.</bf:label>
+      <bf:authorizedAccessPoint>Kipling, Rudyard, 1865-1936.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kipling, Rudyard, 1865-1936.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/14978856title50">
+      <bf:label>[Carpenter Kipling scrapbooks] [graphic].</bf:label>
+      <bf:titleValue>[Carpenter Kipling scrapbooks]</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/14978856title51">
+      <bf:titleType>Cited title:</bf:titleType>
+      <bf:label>Cited title: Carpenter Kipling Collection scrapbooks</bf:label>
+      <bf:titleValue>Carpenter Kipling Collection scrapbooks</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/hasPart/14978856.ttl
+++ b/spec/fixtures/loc/m2b-properties/hasPart/14978856.ttl
@@ -1,0 +1,889 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/14978856annotation46> a bf:Annotation;
+   bf:annotates <http://example.org/14978856>;
+   bf:changeDate "2013-06-03T10:38";
+   bf:derivedFrom <http://example.org/14978856.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/gihc>,
+     <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/14978856helditem68> a bf:HeldItem;
+   bf:custodialHistory "Compiled by Mr. and Mrs. William M. Carpenter. Gift of Mrs. William Montelle Carpenter, 1955.";
+   bf:holdingFor <http://example.org/14978856instance47>;
+   bf:label "Z8465 .C373 1881";
+   bf:shelfMarkLcc "Z8465 .C373 1881" .
+
+<http://example.org/14978856summary12> a bf:Summary;
+   bf:annotationAssertedBy <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:annotationBody "Scrapbooks include various typescript drafts written by William M. Carpenter about Rudyard Kipling's life and document the collection of Rudyard Kipling materials acquired by Carpenter. Also includes numerous ephemeral items relating to the life of Kipling.";
+   bf:label "Summary";
+   bf:summaryOf <http://example.org/14978856> .
+
+<http://example.org/14978856agent48> a bf:Agent;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936."
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856agent49> a bf:Agent;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936."
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856instance47> a bf:Instance,
+     bf:Collection;
+   bf:accessCondition "Restrictions: Poor condition of many of the original clippings within the scrapbooks.";
+   bf:contentsNote "Vol. 1. Proof copy of Kipling's poem \"To the address of W.W.H.\" ; Carbon manuscript copy of fragment of essay by Rudyard Kipling written during the \"From Sea to Sea\" trip, 1889 ; Photostat copies of \"Manuscript from Sea to Sea letters India through Japan, 19 Turnovers\", 1889 (originals in Henry E. Huntington Library). Photographs and negatives. Typewritten transcripts of Kipling correspondence to James Conland, Charles Warren Stoddard and others transcribed by Carpenter. ALS from Sydney Lowe to W.M. Carpenter dated May 17, 1916 -- v. 2. Kipling's writings during the \"American Period\" / W.M. Carpenter. Kipling Society correspondence with Mr. Carpenter. ALS from L.C. Dunsterville to W.M. Carpenter, August 28, 1931. TLS to W.M. Carpenter from Henry H. Conland, February 20, 1928 -- v. 3. Kipling and his college / W.M. Carpenter. Group photograph of Kipling and his schoolmates, ca. 1881. TLS to W.M. Carpenter from Thomas McLean, schoolmate of Kipling from United Services College. On Balfour, Guthrie & Co. letterhead, Tacoma, Washington, dated June 10, 1931. Newspaper clippings from the Civil and Military Gazette, 1888 containing articles by Kipling. Handwritten notes from Mrs. Edmonia Taylor Hill. R.K.'s Allahabad home ; Kipling in San Francisco ; Oregon ; The Kipling creed ; Kipling items copied from newspapers-by W.M.C. ; various comments on individual Kipling titles / W.M. Carpenter. Putnam / Rudyard Kipling. \"Jungle Dinner Feb. 21, 1899\" / Mrs. Hill. TLS to W.M. Carpenter from F.W. Childs, August 9, 1928 and October 11, 1928. Transcripts of letters from W.D. Howells to Aurelia Howells and from Kipling to W.D. Howells. Transcripts of typewritten copies of Last will and testament of ... Rudyard Kipling and Last will and testament of ... Caroline Kipling, widow -- v. 4. William M. Carpenter typescripts relating to \"The Friend\" period in South Africa. Typescript: \"Copy of letter from Mrs. Flora V. Livingston to W.M. Carpenter about Kipling's contributions to 'The Friend'\". Typescript: \"A Burgher of the Free State\" / W.M. Carpenter with handwritten note initialed on first page by L.H. Chandler -- v. 5. Clippings: India, South Africa, America -- v. 6. Clippings: Reviews, Criticisms, Interviews, Addresses, Tributes, Miscellaneous items -- v. 7. Clippings: Kipling's life, homes, family. Vermont, World War I. School days. Honors. Religion-Rosicrucians. Illness. Death. Reviews & criticisms of his writings. Mrs. Kipling's death. Disposal of estate. Lord Birkenhead's biography of R.K. banned by Elsie Kipling Bambridge.";
+   bf:dimensions "30 x 26 cm. and 31 x 27 cm.";
+   bf:extent "7 scrapbooks (ca. 520 items) ;";
+   bf:formDesignation "graphic.";
+   bf:instanceOf <http://example.org/14978856>;
+   bf:instanceTitle <http://example.org/14978856title50>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2007581632"
+   ];
+   bf:modeOfIssuance "monographic";
+   bf:note "Scrapbooks include various typescript drafts written by William M. Carpenter about Rudyard Kipling's life and document the collection of Rudyard Kipling materials acquired by Carpenter. Also includes numerous ephemeral items relating to the life of Kipling.",
+     "Includes four scrapbooks of manuscripts, typescripts, correspondence, transcripts of correspondence, photostat copies of manuscripts, notes, clippings, photographs and other ephemera removed from original binders. Also includes three original scrapbook volumes containing newspaper and magazine clippings from various sources. Two additional volumes containing original correspondence of Rudyard Kipling had been rehoused into one container and are now cataloged under [Carpenter Kipling Collection miscellaneous letters] on lccn 2007581629.",
+     "Title devised by Library staff.",
+     "Compiled by Mr. and Mrs. William M. Carpenter. Gift of Mrs. William Montelle Carpenter, 1955.",
+     "LC collection rehoused in 4 boxes: 27 x 40 x 13 cm. and 3 boxes: 37 x 29 x 8 cm. Original scrapbook binders are included at the back of each box.";
+   bf:providerStatement "1881-1945";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "[1881-1945]"
+   ];
+   bf:titleStatement "Carpenter Kipling scrapbooks";
+   bf:titleVariation <http://example.org/14978856title51> .
+
+<http://example.org/14978856organization26> a bf:Organization;
+   bf:authorizedAccessPoint "Kipling Society--Records and correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Kipling Society--Records and correspondence.";
+     mads:componentList ([
+         a mads:CorporateName,
+           mads:Authority;
+         mads:authoritativeLabel "Kipling Society";
+         mads:elementList ([
+             a mads:NameElement;
+             mads:elementValue "Kipling Society"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Records and correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Records and correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kipling Society--Records and correspondence." .
+
+<http://example.org/14978856organization9> a bf:Organization;
+   bf:authorizedAccessPoint "Carpenter Kipling Collection (Library of Congress)";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Carpenter Kipling Collection (Library of Congress)"
+   ];
+   bf:label "Carpenter Kipling Collection (Library of Congress)" .
+
+<http://example.org/14978856person13> a bf:Person;
+   bf:authorizedAccessPoint "Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Carpenter, W. M. (William Montelle), 1866-1931";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Carpenter, W. M."
+           ] [
+             a mads:FullNameElement;
+             mads:elementValue "(William Montelle),"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1866-1931"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Manuscripts";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Manuscripts."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Carpenter, W. M. (William Montelle), 1866-1931--Manuscripts." .
+
+<http://example.org/14978856person14> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:PersonalName;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936.";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856person15> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936--Manuscripts.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936--Manuscripts.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Kipling, Rudyard, 1865-1936";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Kipling, Rudyard,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1865-1936"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Manuscripts";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Manuscripts."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936--Manuscripts." .
+
+<http://example.org/14978856person16> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Kipling, Rudyard, 1865-1936";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Kipling, Rudyard,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1865-1936"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Manuscripts";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Manuscripts"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Facsimiles";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Facsimiles."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936--Manuscripts--Facsimiles." .
+
+<http://example.org/14978856person17> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936--Miscellanea.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936--Miscellanea.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Kipling, Rudyard, 1865-1936";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Kipling, Rudyard,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1865-1936"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Miscellanea";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Miscellanea."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936--Miscellanea." .
+
+<http://example.org/14978856person18> a bf:Person;
+   bf:authorizedAccessPoint "Carpenter, W. M. (William Montelle), 1866-1931--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Carpenter, W. M. (William Montelle), 1866-1931--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Carpenter, W. M. (William Montelle), 1866-1931";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Carpenter, W. M."
+           ] [
+             a mads:FullNameElement;
+             mads:elementValue "(William Montelle),"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1866-1931"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Carpenter, W. M. (William Montelle), 1866-1931--Correspondence." .
+
+<http://example.org/14978856person19> a bf:Person;
+   bf:authorizedAccessPoint "Carpenter, Lucile Russell--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Carpenter, Lucile Russell--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Carpenter, Lucile Russell";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Carpenter, Lucile Russell"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Carpenter, Lucile Russell--Correspondence." .
+
+<http://example.org/14978856person20> a bf:Person;
+   bf:authorizedAccessPoint "Childs, F. W. (Frederick W.), 1849-1946--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Childs, F. W. (Frederick W.), 1849-1946--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Childs, F. W. (Frederick W.), 1849-1946";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Childs, F. W."
+           ] [
+             a mads:FullNameElement;
+             mads:elementValue "(Frederick W.),"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1849-1946"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Childs, F. W. (Frederick W.), 1849-1946--Correspondence." .
+
+<http://example.org/14978856person21> a bf:Person;
+   bf:authorizedAccessPoint "Conland, Henry H., 1882---Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Conland, Henry H., 1882---Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Conland, Henry H., 1882-";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Conland, Henry H.,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1882-"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Conland, Henry H., 1882---Correspondence." .
+
+<http://example.org/14978856person22> a bf:Person;
+   bf:authorizedAccessPoint "Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Dunsterville, L. C. (Lionel Charles), 1865-1946";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Dunsterville, L. C."
+           ] [
+             a mads:FullNameElement;
+             mads:elementValue "(Lionel Charles),"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1865-1946"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Dunsterville, L. C. (Lionel Charles), 1865-1946--Correspondence." .
+
+<http://example.org/14978856person23> a bf:Person;
+   bf:authorizedAccessPoint "Hill, Edmonia Taylor, -1952--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Hill, Edmonia Taylor, -1952--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Hill, Edmonia Taylor, -1952";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Hill, Edmonia Taylor,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "-1952"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Hill, Edmonia Taylor, -1952--Correspondence." .
+
+<http://example.org/14978856person24> a bf:Person;
+   bf:authorizedAccessPoint "Lowe, Sidney--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Lowe, Sidney--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Lowe, Sidney";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Lowe, Sidney"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Lowe, Sidney--Correspondence." .
+
+<http://example.org/14978856person25> a bf:Person;
+   bf:authorizedAccessPoint "McLean, Thomas--Correspondence.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "McLean, Thomas--Correspondence.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "McLean, Thomas";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "McLean, Thomas"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "McLean, Thomas--Correspondence." .
+
+<http://example.org/14978856person44> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936."
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856person45> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936."
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856person46> a bf:Person;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kipling, Rudyard, 1865-1936."
+   ];
+   bf:label "Kipling, Rudyard, 1865-1936." .
+
+<http://example.org/14978856person7> a bf:Person;
+   bf:authorizedAccessPoint "Carpenter, W. M. (William Montelle), 1866-1931.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Carpenter, W. M. (William Montelle), 1866-1931."
+   ];
+   bf:label "Carpenter, W. M. (William Montelle), 1866-1931." .
+
+<http://example.org/14978856person8> a bf:Person;
+   bf:authorizedAccessPoint "Carpenter, Lucile Russell.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Carpenter, Lucile Russell."
+   ];
+   bf:label "Carpenter, Lucile Russell." .
+
+<http://example.org/14978856title50> a bf:Title;
+   bf:label "[Carpenter Kipling scrapbooks] [graphic].";
+   bf:titleValue "[Carpenter Kipling scrapbooks]" .
+
+<http://example.org/14978856title51> a bf:Title;
+   bf:label "Cited title: Carpenter Kipling Collection scrapbooks";
+   bf:titleType "Cited title:";
+   bf:titleValue "Carpenter Kipling Collection scrapbooks" .
+
+<http://example.org/14978856title6> a bf:Title;
+   bf:label "[Carpenter Kipling scrapbooks] [graphic].";
+   bf:titleValue "[Carpenter Kipling scrapbooks]" .
+
+<http://example.org/14978856topic27> a bf:Topic;
+   bf:authorizedAccessPoint "Authors, English--19th century--Biography";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Authors, English--19th century--Biography";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Authors, English";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Authors, English"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "19th century";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "19th century"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Biography";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Biography."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Authors, English--19th century--Biography" .
+
+<http://example.org/14978856topic28> a bf:Topic;
+   bf:authorizedAccessPoint "Authors, English--20th century--Biography";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Authors, English--20th century--Biography";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Authors, English";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Authors, English"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "20th century";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "20th century"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Biography";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Biography."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Authors, English--20th century--Biography" .
+
+<http://example.org/14978856topic29> a bf:Topic;
+   bf:authorizedAccessPoint "Book collectors--United States--Correspondence";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Book collectors--United States--Correspondence";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Book collectors";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Book collectors"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Correspondence";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Correspondence."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Book collectors--United States--Correspondence" .
+
+<http://example.org/14978856topic30> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Scrapbooks--1920-1960";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Scrapbooks--1920-1960";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Scrapbooks";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Scrapbooks"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1920-1960";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1920-1960."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Scrapbooks--1920-1960" .
+
+<http://example.org/14978856topic31> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Photographic prints--1880-1890";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Photographic prints--1880-1890";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Photographic prints";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Photographic prints"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1890";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1890."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Photographic prints--1880-1890" .
+
+<http://example.org/14978856topic32> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Photographic prints--1920-1930";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Photographic prints--1920-1930";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Photographic prints";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Photographic prints"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1920-1930";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1920-1930."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Photographic prints--1920-1930" .
+
+<http://example.org/14978856topic33> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Portrait photographs--1920-1930";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Portrait photographs--1920-1930";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Portrait photographs";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Portrait photographs"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1920-1930";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1920-1930."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Portrait photographs--1920-1930" .
+
+<http://example.org/14978856topic34> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Clippings--1920-1960";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Clippings--1920-1960";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Clippings";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Clippings"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1920-1960";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1920-1960."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Clippings--1920-1960" .
+
+<http://example.org/14978856topic35> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Stats--1920-1930";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Stats--1920-1930";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Stats";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Stats"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1920-1930";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1920-1930."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Stats--1920-1930" .
+
+<http://example.org/14978856work39> a bf:Work;
+   bf:authorizedAccessPoint "Civil & military gazette (Lahore, Pakistan)";
+   bf:title "Civil & military gazette (Lahore, Pakistan)" .
+
+<http://example.org/14978856work40> a bf:Work;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936. From sea to sea.";
+   bf:contributor <http://example.org/14978856person44>;
+   bf:title "From sea to sea." .
+
+<http://example.org/14978856work41> a bf:Work;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936. Putnam.";
+   bf:contributor <http://example.org/14978856person45>;
+   bf:title "Putnam." .
+
+<http://example.org/14978856work42> a bf:Work;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936. To the address of W.W.H.";
+   bf:contributor <http://example.org/14978856person46>;
+   bf:title "To the address of W.W.H." .
+
+<http://example.org/14978856work43> a bf:Work;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936. Putnam";
+   bf:contributor <http://example.org/14978856agent48>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2007567098>;
+   bf:partOf <http://example.org/14978856>;
+   bf:title "Putnam" .
+
+<http://example.org/14978856work44> a bf:Work;
+   bf:authorizedAccessPoint "Kipling, Rudyard, 1865-1936. Putnam";
+   bf:contributor <http://example.org/14978856agent49>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2007567098>;
+   bf:partOf <http://example.org/14978856>;
+   bf:title "Putnam" .
+
+<http://example.org/14978856> a bf:Work,
+     bf:Text,
+     bf:StillImage;
+   bf:authorizedAccessPoint "Carpenter, W. M. (William Montelle), 1866-1931. [Carpenter Kipling scrapbooks] [graphic].[Carpenter Kipling scrapbooks]",
+     "carpenterlucilerussellkiplingrudyard18651936kiplingrudyard18651936kiplingrudyard18651936carpenterkiplingcollectionlibraryofcongresscarpenterwmwilliammontelle18661931carpenterkiplingscrapbooksengworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/Z8465>;
+   bf:contributor <http://example.org/14978856person8>,
+     <http://example.org/14978856organization9>;
+   bf:creator <http://example.org/14978856person7>;
+   bf:findingAidNote "Finding aid consists of detailed list of contents of each volume compiled by Library staff laid in each box.";
+   bf:hasPart <http://example.org/14978856work41>,
+     <http://example.org/14978856work42>,
+     <http://example.org/14978856work43>,
+     <http://example.org/14978856work44>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:relatedResource <http://example.org/14978856work39>,
+     <http://example.org/14978856work40>;
+   bf:subject <http://example.org/14978856person13>,
+     <http://example.org/14978856person14>,
+     <http://example.org/14978856person15>,
+     <http://example.org/14978856person16>,
+     <http://example.org/14978856person17>,
+     <http://example.org/14978856person18>,
+     <http://example.org/14978856person19>,
+     <http://example.org/14978856person20>,
+     <http://example.org/14978856person21>,
+     <http://example.org/14978856person22>,
+     <http://example.org/14978856person23>,
+     <http://example.org/14978856person24>,
+     <http://example.org/14978856person25>,
+     <http://example.org/14978856organization26>,
+     <http://example.org/14978856topic27>,
+     <http://example.org/14978856topic28>,
+     <http://example.org/14978856topic29>,
+     <http://example.org/14978856topic30>,
+     <http://example.org/14978856topic31>,
+     <http://example.org/14978856topic32>,
+     <http://example.org/14978856topic33>,
+     <http://example.org/14978856topic34>,
+     <http://example.org/14978856topic35>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us>,
+     <http://id.loc.gov/vocabulary/geographicAreas/e-uk-en>;
+   bf:workTitle <http://example.org/14978856title6> .

--- a/spec/fixtures/loc/m2b-properties/hasPart/5217778.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hasPart/5217778.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03125cam a2200625 a 4500</leader>
   <controlfield tag="001">5217778</controlfield>
   <controlfield tag="005">20130430133402.0</controlfield>
@@ -222,4 +222,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5217778</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hasPart/5217778.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/hasPart/5217778.rdfxml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/5217778">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Zhu, Weigao, active 17th century-18th century. Ruijin xian zhi</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Ruijin xian zhi.</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/5217778title6"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person7"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person8"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person9"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person10"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person11"/>
+      <bf:contributor rdf:resource="http://example.org/5217778person12"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/chi"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/DS793.J785"/>
+      <bf:classification rdf:resource="http://example.org/5217778classification15"/>
+      <bf:hasPart rdf:resource="http://example.org/5217778work16"/>
+      <bf:hasPart rdf:resource="http://example.org/5217778work17"/>
+      <bf:relatedWork rdf:resource="http://example.org/5217778work18"/>
+      <bf:relatedWork rdf:resource="http://example.org/5217778work19"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">zhuweigaoactive17thcentury18thcenturyyangchangshiactive17thcenturyguoyihaoactive17thcentury18thcenturyzhuyunyingactive17thcentury18thcenturyxiechongbaactive17thcentury18thcenturyzhangzhenejinshi168588001ruijinxianzhichiworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/5217778work16">
+      <bf:title>Xu xiu Ruijin xian zhi.</bf:title>
+      <bf:authorizedAccessPoint>Xu xiu Ruijin xian zhi.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">續修瑞金縣志. 1992.</bf:authorizedAccessPoint>
+      <bf:originDate>1992.</bf:originDate>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/5217778work17">
+      <bf:title>Shangyou xian zhi.</bf:title>
+      <bf:authorizedAccessPoint>Shangyou xian zhi.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">上猶縣志. 1992.</bf:authorizedAccessPoint>
+      <bf:originDate>1992.</bf:originDate>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/5217778work18">
+      <bf:title>(Kangxi) Xu xiu Ruijin xian zhi.</bf:title>
+      <bf:authorizedAccessPoint>(Kangxi) Xu xiu Ruijin xian zhi.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">(康熙)　續修瑞金縣志.</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/5217778work19">
+      <bf:title>(Kangxi) Shangyou xian zhi.</bf:title>
+      <bf:authorizedAccessPoint>(Kangxi) Shangyou xian zhi.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">(康熙)　上猶縣志.</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/5217778instance22">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/5217778title25"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/7501309140"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9787501309146"/>
+      <bf:responsibilityStatement xml:lang="zh-hani">[朱維高修 ; 楊長世纂].  (康熙) 續修瑞金縣志 / [郭一豪修 ; 朱雲映, 謝重拔纂]. (康熙) 上猶縣志 / [章振萼纂修].</bf:responsibilityStatement>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Shu mu wen xian chu ban she </bf:label>
+                  <bf:label xml:lang="zh-hani">書目文獻出版社 :</bf:label>
+                  <bf:label xml:lang="zh-hani">新華書店北京发行所发行</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Beijing </bf:label>
+                  <bf:label xml:lang="zh-hani">北京 :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1992</bf:providerDate>
+            <bf:providerDate xml:lang="zh-hani">1992.</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Xin hua shu dian Beijing fa xing suo fa xing</bf:label>
+                  <bf:label xml:lang="zh-hani">書目文獻出版社 :</bf:label>
+                  <bf:label xml:lang="zh-hani">新華書店北京发行所发行</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerDate>1992</bf:providerDate>
+            <bf:providerDate xml:lang="zh-hani">1992.</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:edition xml:lang="zh-hani">北京第1版.</bf:edition>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>374 p. :</bf:extent>
+      <bf:dimensions>27 cm.</bf:dimensions>
+      <bf:illustrationNote>ill., maps ;</bf:illustrationNote>
+      <bf:titleStatement>(Kangxi) Ruijin xian zhi</bf:titleStatement>
+      <bf:edition>Beijing di 1 ban.</bf:edition>
+      <bf:providerStatement>Beijing : Shu mu wen xian chu ban she : Xin hua shu dian Beijing fa xing suo fa xing, 1992.</bf:providerStatement>
+      <bf:note>First work originally published: 1683. 2nd work originally published: 1710. 3rd work originally published: 1697.</bf:note>
+      <bf:note>Each page represents 2 leaves of the original.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>93120144</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>(CStRLIN)DCLP93-B14905</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/systemNumber"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:instanceOf rdf:resource="http://example.org/5217778"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/5217778annotation21">
+      <bf:derivedFrom rdf:resource="http://example.org/5217778.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/hnk"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/cstrlin"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/miua"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlcr"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-04-30T13:34</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/5217778"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/5217778helditem44">
+      <bf:label>DS793.J785 J85 1992</bf:label>
+      <bf:shelfMarkLcc>DS793.J785 J85 1992</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/5217778instance22"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/5217778title6">
+      <bf:titleValue>Ruijin xian zhi.</bf:titleValue>
+      <bf:titleValue xml:lang="zh-hani">瑞金縣志.</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/5217778person7">
+      <bf:label>Zhu, Weigao, active 17th century-18th century.</bf:label>
+      <bf:authorizedAccessPoint>Zhu, Weigao, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">朱維高, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Zhu, Weigao, active 17th century-18th century.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/5217778person8">
+      <bf:label>Yang, Changshi, active 17th century.</bf:label>
+      <bf:authorizedAccessPoint>Yang, Changshi, active 17th century.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">楊長世, active 17th century.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Yang, Changshi, active 17th century.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/5217778person9">
+      <bf:label>Guo, Yihao, active 17th century-18th century.</bf:label>
+      <bf:authorizedAccessPoint>Guo, Yihao, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">郭一豪, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Guo, Yihao, active 17th century-18th century.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/5217778person10">
+      <bf:label>Zhu, Yunying, active 17th century-18th century.</bf:label>
+      <bf:authorizedAccessPoint>Zhu, Yunying, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">朱雲映, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Zhu, Yunying, active 17th century-18th century.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/5217778person11">
+      <bf:label>Xie, Chongba, active 17th century-18th century.</bf:label>
+      <bf:authorizedAccessPoint>Xie, Chongba, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">謝重拔, active 17th century-18th century.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Xie, Chongba, active 17th century-18th century.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/5217778person12">
+      <bf:label>Zhang, Zhen'e, jin shi 1685.</bf:label>
+      <bf:authorizedAccessPoint>Zhang, Zhen'e, jin shi 1685.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">章振萼, jin shi 1685.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Zhang, Zhen'e, jin shi 1685.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Classification rdf:about="http://example.org/5217778classification15">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>951/.222</bf:classificationNumber>
+      <bf:label>951/.222</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>20</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/5217778title25">
+      <bf:label>(Kangxi) Ruijin xian zhi / [Zhu Weigao xiu ; Yang Changshi zuan].  (Kangxi) Xu xiu Ruijin xian zhi / [Guo Yihao xiu ; Zhu Yunying, Xie Chongba zuan].  (Kangxi) Shangyou xian zhi / [Zhang Zhen'e zuan xiu].</bf:label>
+      <bf:titleValue>(Kangxi) Ruijin xian zhi</bf:titleValue>
+      <bf:titleValue xml:lang="zh-hani">(康熙) 瑞金縣志</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/hasPart/5217778.ttl
+++ b/spec/fixtures/loc/m2b-properties/hasPart/5217778.ttl
@@ -1,0 +1,189 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/5217778annotation21> a bf:Annotation;
+   bf:annotates <http://example.org/5217778>;
+   bf:changeDate "2013-04-30T13:34";
+   bf:derivedFrom <http://example.org/5217778.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/cstrlin>,
+     <http://id.loc.gov/vocabulary/organizations/miua>,
+     <http://id.loc.gov/vocabulary/organizations/dlcr>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/hnk>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/5217778helditem44> a bf:HeldItem;
+   bf:holdingFor <http://example.org/5217778instance22>;
+   bf:label "DS793.J785 J85 1992";
+   bf:shelfMarkLcc "DS793.J785 J85 1992" .
+
+<http://example.org/5217778classification15> a bf:Classification;
+   bf:classificationEdition "full",
+     "20";
+   bf:classificationNumber "951/.222";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "951/.222" .
+
+<http://example.org/5217778instance22> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "27 cm.";
+   bf:edition "北京第1版."@zh-hani,
+     "Beijing di 1 ban.";
+   bf:extent "374 p. :";
+   bf:illustrationNote "ill., maps ;";
+   bf:instanceOf <http://example.org/5217778>;
+   bf:instanceTitle <http://example.org/5217778title25>;
+   bf:isbn10 <http://isbn.example.org/7501309140>;
+   bf:isbn13 <http://isbn.example.org/9787501309146>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "93120144"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:note "First work originally published: 1683. 2nd work originally published: 1710. 3rd work originally published: 1697.",
+     "Each page represents 2 leaves of the original.";
+   bf:providerStatement "Beijing : Shu mu wen xian chu ban she : Xin hua shu dian Beijing fa xing suo fa xing, 1992.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1992",
+       "1992."@zh-hani;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Shu mu wen xian chu ban she ",
+         "書目文獻出版社 :"@zh-hani,
+         "新華書店北京发行所发行"@zh-hani
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Beijing ",
+         "北京 :"@zh-hani
+     ]
+   ],  [
+     a bf:Provider;
+     bf:providerDate "1992",
+       "1992."@zh-hani;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Xin hua shu dian Beijing fa xing suo fa xing",
+         "書目文獻出版社 :"@zh-hani,
+         "新華書店北京发行所发行"@zh-hani
+     ]
+   ];
+   bf:responsibilityStatement "[朱維高修 ; 楊長世纂].  (康熙) 續修瑞金縣志 / [郭一豪修 ; 朱雲映, 謝重拔纂]. (康熙) 上猶縣志 / [章振萼纂修]."@zh-hani;
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:systemNumber;
+     bf:identifierValue "(CStRLIN)DCLP93-B14905"
+   ];
+   bf:titleStatement "(Kangxi) Ruijin xian zhi" .
+
+<http://example.org/5217778person10> a bf:Person;
+   bf:authorizedAccessPoint "Zhu, Yunying, active 17th century-18th century.",
+     "朱雲映, active 17th century-18th century."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Zhu, Yunying, active 17th century-18th century."
+   ];
+   bf:label "Zhu, Yunying, active 17th century-18th century." .
+
+<http://example.org/5217778person11> a bf:Person;
+   bf:authorizedAccessPoint "Xie, Chongba, active 17th century-18th century.",
+     "謝重拔, active 17th century-18th century."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Xie, Chongba, active 17th century-18th century."
+   ];
+   bf:label "Xie, Chongba, active 17th century-18th century." .
+
+<http://example.org/5217778person12> a bf:Person;
+   bf:authorizedAccessPoint "Zhang, Zhen'e, jin shi 1685.",
+     "章振萼, jin shi 1685."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Zhang, Zhen'e, jin shi 1685."
+   ];
+   bf:label "Zhang, Zhen'e, jin shi 1685." .
+
+<http://example.org/5217778person7> a bf:Person;
+   bf:authorizedAccessPoint "Zhu, Weigao, active 17th century-18th century.",
+     "朱維高, active 17th century-18th century."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Zhu, Weigao, active 17th century-18th century."
+   ];
+   bf:label "Zhu, Weigao, active 17th century-18th century." .
+
+<http://example.org/5217778person8> a bf:Person;
+   bf:authorizedAccessPoint "Yang, Changshi, active 17th century.",
+     "楊長世, active 17th century."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Yang, Changshi, active 17th century."
+   ];
+   bf:label "Yang, Changshi, active 17th century." .
+
+<http://example.org/5217778person9> a bf:Person;
+   bf:authorizedAccessPoint "Guo, Yihao, active 17th century-18th century.",
+     "郭一豪, active 17th century-18th century."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Guo, Yihao, active 17th century-18th century."
+   ];
+   bf:label "Guo, Yihao, active 17th century-18th century." .
+
+<http://example.org/5217778title25> a bf:Title;
+   bf:label "(Kangxi) Ruijin xian zhi / [Zhu Weigao xiu ; Yang Changshi zuan].  (Kangxi) Xu xiu Ruijin xian zhi / [Guo Yihao xiu ; Zhu Yunying, Xie Chongba zuan].  (Kangxi) Shangyou xian zhi / [Zhang Zhen'e zuan xiu].";
+   bf:titleValue "(Kangxi) Ruijin xian zhi",
+     "(康熙) 瑞金縣志"@zh-hani .
+
+<http://example.org/5217778title6> a bf:Title;
+   bf:titleValue "Ruijin xian zhi.",
+     "瑞金縣志."@zh-hani .
+
+<http://example.org/5217778work16> a bf:Work;
+   bf:authorizedAccessPoint "Xu xiu Ruijin xian zhi.",
+     "續修瑞金縣志. 1992."@zh-hani;
+   bf:originDate "1992.";
+   bf:title "Xu xiu Ruijin xian zhi." .
+
+<http://example.org/5217778work17> a bf:Work;
+   bf:authorizedAccessPoint "Shangyou xian zhi.",
+     "上猶縣志. 1992."@zh-hani;
+   bf:originDate "1992.";
+   bf:title "Shangyou xian zhi." .
+
+<http://example.org/5217778work18> a bf:Work;
+   bf:authorizedAccessPoint "(Kangxi) Xu xiu Ruijin xian zhi.",
+     "(康熙)　續修瑞金縣志."@zh-hani;
+   bf:title "(Kangxi) Xu xiu Ruijin xian zhi." .
+
+<http://example.org/5217778work19> a bf:Work;
+   bf:authorizedAccessPoint "(Kangxi) Shangyou xian zhi.",
+     "(康熙)　上猶縣志."@zh-hani;
+   bf:title "(Kangxi) Shangyou xian zhi." .
+
+<http://example.org/5217778> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Zhu, Weigao, active 17th century-18th century. Ruijin xian zhi",
+     "zhuweigaoactive17thcentury18thcenturyyangchangshiactive17thcenturyguoyihaoactive17thcentury18thcenturyzhuyunyingactive17thcentury18thcenturyxiechongbaactive17thcentury18thcenturyzhangzhenejinshi168588001ruijinxianzhichiworktext"@x-bf-hash;
+   bf:classification <http://example.org/5217778classification15>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/DS793.J785>;
+   bf:contributor <http://example.org/5217778person7>,
+     <http://example.org/5217778person8>,
+     <http://example.org/5217778person9>,
+     <http://example.org/5217778person10>,
+     <http://example.org/5217778person11>,
+     <http://example.org/5217778person12>;
+   bf:hasPart <http://example.org/5217778work16>,
+     <http://example.org/5217778work17>;
+   bf:language <http://id.loc.gov/vocabulary/languages/chi>;
+   bf:relatedWork <http://example.org/5217778work18>,
+     <http://example.org/5217778work19>;
+   bf:workTitle <http://example.org/5217778title6>;
+   mads:authoritativeLabel "Ruijin xian zhi." .

--- a/spec/fixtures/loc/m2b-properties/hdl/11628622.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hdl/11628622.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>07792ckc a2201081 a 4500</leader>
   <controlfield tag="001">11628622</controlfield>
   <controlfield tag="005">20150626082430.0</controlfield>
@@ -386,4 +386,4 @@
     <subfield code="v">obj.</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11628622</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/hdl/5802339.marcxml
+++ b/spec/fixtures/loc/m2b-properties/hdl/5802339.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>06411cpcaa2201021 i 4500</leader>
   <controlfield tag="001">5802339</controlfield>
   <controlfield tag="005">20150810144829.0</controlfield>
@@ -365,4 +365,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">mss/ead</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5802339</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/holdingFor/15532740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/holdingFor/15532740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01218ccm a2200361 a 4500</leader>
   <controlfield tag="001">15532740</controlfield>
   <controlfield tag="005">20090205092213.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="955" ind1=" " ind2=" ">
     <subfield code="a">fd09 2008-11-24 z-processor</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15532740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifier/11346685.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifier/11346685.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01830cas a2200481 a 4500</leader>
   <controlfield tag="001">11346685</controlfield>
   <controlfield tag="005">20130303163042.0</controlfield>
@@ -163,4 +163,4 @@
     <subfield code="b">MUS</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11346685</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierAssigner/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierAssigner/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierQualifier/14548737.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierQualifier/14548737.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01320cam a2200325 a 4500</leader>
   <controlfield tag="001">14548737</controlfield>
   <controlfield tag="005">20070807153938.0</controlfield>
@@ -92,4 +92,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">ODE-nd</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14548737</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierQualifier/14688108.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierQualifier/14688108.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01046cjm a22003017a 4500</leader>
   <controlfield tag="001">14688108</controlfield>
   <controlfield tag="005">20070108143727.0</controlfield>
@@ -82,4 +82,4 @@
   <datafield tag="650" ind1=" " ind2="0">
     <subfield code="a">Songs, Persian.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14688108</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierQualifier/15532740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierQualifier/15532740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01218ccm a2200361 a 4500</leader>
   <controlfield tag="001">15532740</controlfield>
   <controlfield tag="005">20090205092213.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="955" ind1=" " ind2=" ">
     <subfield code="a">fd09 2008-11-24 z-processor</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15532740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierScheme/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierScheme/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierStatus/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierStatus/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/identifierValue/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-properties/identifierValue/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/illustrationNote/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/illustrationNote/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/immediateAcquisition/11628622.marcxml
+++ b/spec/fixtures/loc/m2b-properties/immediateAcquisition/11628622.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>07792ckc a2201081 a 4500</leader>
   <controlfield tag="001">11628622</controlfield>
   <controlfield tag="005">20150626082430.0</controlfield>
@@ -386,4 +386,4 @@
     <subfield code="v">obj.</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11628622</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/index/13122894.marcxml
+++ b/spec/fixtures/loc/m2b-properties/index/13122894.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>06754ckc a2200889 a 4500</leader>
   <controlfield tag="001">13122894</controlfield>
   <controlfield tag="005">20131127195842.0</controlfield>
@@ -325,4 +325,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="v">obj.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13122894</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/index/13122894.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/index/13122894.rdfxml
@@ -1,0 +1,1227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/13122894">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/StillImage"/>
+      <bf:authorizedAccessPoint>Abdülhamid II, Sultan of the Turks, 1842-1918 Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].Abdul-Hamid II collection of photographs of the Ottoman Empire</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/13122894title5"/>
+      <relators:dnr rdf:resource="http://example.org/13122894person6"/>
+      <relators:pht rdf:resource="http://example.org/13122894organization7"/>
+      <relators:pht rdf:resource="http://example.org/13122894organization8"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/ota"/>
+      <bf:index rdf:resource="http://example.org/13122894work10"/>
+      <bf:index rdf:resource="http://example.org/13122894work11"/>
+      <bf:subject rdf:resource="http://example.org/13122894person13"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic14"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic15"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic16"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic17"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic18"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic19"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic20"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic21"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic22"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic23"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic24"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic25"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic26"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic27"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic28"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic29"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic30"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic31"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic32"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic33"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic34"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic35"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic36"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic37"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic38"/>
+      <bf:subject rdf:resource="http://example.org/13122894topic39"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/a-tu"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">abdülhamidiisultanoftheturks18421918abdullahfrèressebahjoaillierabdulhamidiicollectionofphotographsoftheottomanempireotaworkstillimage</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13122894work10">
+      <bf:authorizedAccessPoint>Collection profile available online</bf:authorizedAccessPoint>
+      <bf:title>Collection profile available online</bf:title>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13122894work11">
+      <bf:authorizedAccessPoint>A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See</bf:authorizedAccessPoint>
+      <bf:title>A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See</bf:title>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/13122894instance14">
+      <bf:hdl rdf:resource="hdl.loc.gov/loc.pnp/pp.ahii"/>
+      <bf:instanceOf rdf:resource="http://example.org/13122894work10"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/13122894instance15">
+      <bf:hdl rdf:resource="http://hdl.loc.gov/loc.gdc/lcoa1.about"/>
+      <bf:instanceOf rdf:resource="http://example.org/13122894work11"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/13122894instance43">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Collection"/>
+      <bf:instanceTitle rdf:resource="http://example.org/13122894title46"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:copyrightDate>1880-1893</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>monographic</bf:modeOfIssuance>
+      <bf:extent>51 albums ;</bf:extent>
+      <bf:dimensions>32 x 19 in. or smaller.</bf:dimensions>
+      <bf:titleStatement>Abdul-Hamid II collection of photographs of the Ottoman Empire</bf:titleStatement>
+      <bf:formDesignation>graphic.</bf:formDesignation>
+      <bf:providerStatement>1880-1893.</bf:providerStatement>
+      <bf:accessCondition>Please use digital and print surrogates instead originals, following preservation policy.</bf:accessCondition>
+      <bf:accessCondition>Original albums; Restricted access: Materials extremely fragile;</bf:accessCondition>
+      <bf:immediateAcquisition>Gift; Abdülhamid II; 1893-1894.</bf:immediateAcquisition>
+      <bf:note>These photographic albums portray the Ottoman Empire during the reign of one of its last sultans, Abdul-Hamid  II. They highlight the modernization of numerous aspects of the Ottoman Empire. Most of the places depicted are within the boundaries of modern-day Turkey, but buildings and sites in Iraq, Lebanon, Greece and other countries are also included. The images show students and educational facilities, including law, medical and military schools; well-equipped army and navy personnel and facilities; technologically advanced lifesaving and fire fighting brigades; factories; mines; harbors; hospitals; and government buildings. The     collection also documents historic Byzantine and Ottoman monuments, mosques, mosaics, fountains, palaces, and mausoleums, and includes panoramic landscapes and urban scenes. Other photographs depict Abdul Hamid's Yildiz Palace, yacht, and horses.</bf:note>
+      <bf:note>Well-known Ottoman commercial photographers such as Abdullah Frères, Sebah &amp; Joaillier, and Phèbus took the bulk of the photographs. Turkish military photographer Ali Rıza Pasa and the Photographic Unit of the Imperial School of Engineering also contributed numerous images.</bf:note>
+      <bf:note>No known restrictions on publication.</bf:note>
+      <bf:note>Collection title devised by Library staff.</bf:note>
+      <bf:note>Albums include four major subject categories: Category I: views, buildings, monuments and antiquities (LOTS 9515, 9516, 9517, 9518, 9523, 9524, 9528, 9529, 9532, 9533, 9534, 9535, 9541, 11907, 11910, 11912, 11913); Category II: military, naval, rescue services and military and industrial facilities (LOTS 9521, 9522, 9536, 9537, 9539, 9540, 9543, 9545, 11905, 11906, 11909, 11911, 11914, 11915, 11917, 11918, 11919); Category III: educational facilities (LOTS 9511, 9512, 9513, 9514, 9519, 9520, 9525, 9526, 9527, 9530, 9531, 9538, 9542, 9544, 11908); and Category IV: horses and imperial stables (LOTS 9546, 11916)</bf:note>
+      <bf:note>Photographs are chiefly albumen, some gelatin silver.</bf:note>
+      <bf:note>Black-and-white copy photographs are also available for reference purposes under LOT call numbers.</bf:note>
+      <bf:note>Digitized images of all items in the collection display with their associated catalog records in the Prints &amp; Photographs Division Online Catalog,</bf:note>
+      <bf:note>Guide to the Special Collections of Prints &amp; Photographs in the Library of Congress / compiled by Paul Vanderbilt. Washington, D.C. : 1955,</bf:note>
+      <bf:note>Special Collections in the Library of Congress / compiled by Annette Melville. Washington, D.C. : Library of Congress, 1980,</bf:note>
+      <bf:note>Abdul-Hamid II (1842-1918), an avid collector and promoter of photography, appears to have conceived this collection as a portrait of his empire for a western audience. He presented a copy of the survey to the Library of Congress in 1893 or 1894. He also gave another almost identical collection to the British Museum (now in the British Library).</bf:note>
+      <bf:note>Imperial self-portrait: The Ottoman Empire as revealed in the Sultan Abdul Hamid II's Photographic Albums. Edited by Carney E.S. Gavin and the Harvard Semitic Museum. Journal of Turkish Studies, v. 12, 1988. [Cambridge, Mass] : Harvard University, 1988.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2003652945</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:arrangement rdf:resource="http://example.org/13122894arrangement70"/>
+      <bf:instanceOf rdf:resource="http://example.org/13122894"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/13122894instance44">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <bf:label>Electronic Resource</bf:label>
+      <bf:hdl rdf:resource="http://hdl.loc.gov/loc.pnp/pp.ahii"/>
+      <bf:instanceOf rdf:resource="http://example.org/13122894"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/13122894annotation42">
+      <bf:derivedFrom rdf:resource="http://example.org/13122894.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/gihc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-11-27T19:58</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/13122894"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/13122894helditem72">
+      <bf:label/>
+      <bf:custodialHistory>Abdul-Hamid II (1842-1918), an avid collector and promoter of photography, appears to have conceived this collection as a portrait of his empire for a western audience. He presented a copy of the survey to the Library of Congress in 1893 or 1894. He also gave another almost identical collection to the British Museum (now in the British Library).</bf:custodialHistory>
+      <bf:heldBy>Library of Congress</bf:heldBy>
+      <bf:subLocation>Prints and Photographs Division</bf:subLocation>
+      <bf:holdingFor rdf:resource="http://example.org/13122894instance43"/>
+   </bf:HeldItem>
+   <bf:Summary rdf:about="http://example.org/13122894summary12">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Summary"/>
+      <bf:label>Summary</bf:label>
+      <bf:annotationAssertedBy rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:annotationBody>These photographic albums portray the Ottoman Empire during the reign of one of its last sultans, Abdul-Hamid  II. They highlight the modernization of numerous aspects of the Ottoman Empire. Most of the places depicted are within the boundaries of modern-day Turkey, but buildings and sites in Iraq, Lebanon, Greece and other countries are also included. The images show students and educational facilities, including law, medical and military schools; well-equipped army and navy personnel and facilities; technologically advanced lifesaving and fire fighting brigades; factories; mines; harbors; hospitals; and government buildings. The     collection also documents historic Byzantine and Ottoman monuments, mosques, mosaics, fountains, palaces, and mausoleums, and includes panoramic landscapes and urban scenes. Other photographs depict Abdul Hamid's Yildiz Palace, yacht, and horses.</bf:annotationBody>
+      <bf:summaryOf rdf:resource="http://example.org/13122894"/>
+   </bf:Summary>
+   <bf:Title rdf:about="http://example.org/13122894title5">
+      <bf:label>Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].</bf:label>
+      <bf:titleValue>Abdul-Hamid II collection of photographs of the Ottoman Empire</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/13122894person6">
+      <bf:label>Abdülhamid II, Sultan of the Turks, 1842-1918</bf:label>
+      <bf:authorizedAccessPoint>Abdülhamid II, Sultan of the Turks, 1842-1918</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Abdülhamid II, Sultan of the Turks, 1842-1918</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Organization rdf:about="http://example.org/13122894organization7">
+      <bf:label>Abdullah frères</bf:label>
+      <bf:authorizedAccessPoint>Abdullah frères</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Abdullah frères</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Organization rdf:about="http://example.org/13122894organization8">
+      <bf:label>Sebah &amp; Joaillier</bf:label>
+      <bf:authorizedAccessPoint>Sebah &amp; Joaillier</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Sebah &amp; Joaillier</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Person rdf:about="http://example.org/13122894person13">
+      <bf:authorizedAccessPoint>Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects.</bf:authorizedAccessPoint>
+      <bf:label>Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource=""/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:PersonalName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Abdülhamid Sultan of the Turks, 1842-1918</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:FullNameElement>
+                        <madsrdf:elementValue>Abdülhamid</madsrdf:elementValue>
+                     </madsrdf:FullNameElement>
+                     <madsrdf:TermsOfAddressNameElement>
+                        <madsrdf:elementValue>Sultan of the Turks,</madsrdf:elementValue>
+                     </madsrdf:TermsOfAddressNameElement>
+                     <madsrdf:DateNameElement>
+                        <madsrdf:elementValue>1842-1918</madsrdf:elementValue>
+                     </madsrdf:DateNameElement>
+                  </madsrdf:elementList>
+               </madsrdf:PersonalName>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Associated objects</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Associated objects.</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Topic rdf:about="http://example.org/13122894topic14">
+      <bf:authorizedAccessPoint>Government facilities--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Government facilities--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Government facilities--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Government facilities</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Government facilities</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic15">
+      <bf:authorizedAccessPoint>Educational facilities--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Educational facilities--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Educational facilities--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Educational facilities</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Educational facilities</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic16">
+      <bf:authorizedAccessPoint>Military facilities--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Military facilities--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Military facilities--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Military facilities</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Military facilities</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic17">
+      <bf:authorizedAccessPoint>Lifesaving--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Lifesaving--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Lifesaving--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Lifesaving</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Lifesaving</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic18">
+      <bf:authorizedAccessPoint>Students--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Students--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Students--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Students</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Students</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic19">
+      <bf:authorizedAccessPoint>Mosaics--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Mosaics--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Mosaics--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Mosaics</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Mosaics</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic20">
+      <bf:authorizedAccessPoint>Fountains--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Fountains--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Fountains--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Fountains</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Fountains</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic21">
+      <bf:authorizedAccessPoint>Tombs &amp; sepulchral monuments--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Tombs &amp; sepulchral monuments--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Tombs &amp; sepulchral monuments--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Tombs &amp; sepulchral monuments</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Tombs &amp; sepulchral monuments</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic22">
+      <bf:authorizedAccessPoint>Horses--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Horses--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Horses--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Horses</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Horses</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic23">
+      <bf:authorizedAccessPoint>Mosques--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Mosques--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Mosques--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Mosques</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Mosques</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic24">
+      <bf:authorizedAccessPoint>Castles &amp; palaces--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Castles &amp; palaces--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Castles &amp; palaces--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Castles &amp; palaces</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Castles &amp; palaces</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic25">
+      <bf:authorizedAccessPoint>Hospitals--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Hospitals--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Hospitals--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Hospitals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Hospitals</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic26">
+      <bf:authorizedAccessPoint>Ships--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Ships--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Ships--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Ships</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Ships</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic27">
+      <bf:authorizedAccessPoint>Fire fighting--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Fire fighting--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Fire fighting--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Fire fighting</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Fire fighting</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic28">
+      <bf:authorizedAccessPoint>Forts &amp; fortifications--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Forts &amp; fortifications--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Forts &amp; fortifications--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Forts &amp; fortifications</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Forts &amp; fortifications</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic29">
+      <bf:authorizedAccessPoint>City walls--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>City walls--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>City walls--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>City walls</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>City walls</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic30">
+      <bf:authorizedAccessPoint>Yachts--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Yachts--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Yachts--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Yachts</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Yachts</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic31">
+      <bf:authorizedAccessPoint>Factories--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Factories--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Factories--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Factories</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Factories</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic32">
+      <bf:authorizedAccessPoint>Navies--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Navies--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Navies--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Navies</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Navies</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic33">
+      <bf:authorizedAccessPoint>Military personnel--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Military personnel--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Military personnel--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Military personnel</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Military personnel</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic34">
+      <bf:authorizedAccessPoint>Military life--Turkey--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Military life--Turkey--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Military life--Turkey--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lctgm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Military life</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Military life</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Turkey</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Turkey</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lctgm</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic35">
+      <bf:authorizedAccessPoint>Cityscapes--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Cityscapes--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Cityscapes--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Cityscapes</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Cityscapes</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic36">
+      <bf:authorizedAccessPoint>Photograph albums--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Photograph albums--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Photograph albums--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Photograph albums</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Photograph albums</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic37">
+      <bf:authorizedAccessPoint>Portrait photographs--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Portrait photographs--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Portrait photographs--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Portrait photographs</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Portrait photographs</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic38">
+      <bf:authorizedAccessPoint>Group portraits--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Group portraits--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Group portraits--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Group portraits</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Group portraits</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/13122894topic39">
+      <bf:authorizedAccessPoint>Albumen prints--1880-1900</bf:authorizedAccessPoint>
+      <bf:label>Albumen prints--1880-1900</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Albumen prints--1880-1900</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/gmgpc"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Albumen prints</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Albumen prints</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+               <madsrdf:Temporal>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>1880-1900</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TemporalElement>
+                        <madsrdf:elementValue>1880-1900.</madsrdf:elementValue>
+                     </madsrdf:TemporalElement>
+                  </madsrdf:elementList>
+               </madsrdf:Temporal>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/gmgpc</bf:authoritySource>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/13122894title46">
+      <bf:label>Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].</bf:label>
+      <bf:titleValue>Abdul-Hamid II collection of photographs of the Ottoman Empire</bf:titleValue>
+   </bf:Title>
+   <bf:Arrangement rdf:about="http://example.org/13122894arrangement70">
+      <bf:materialOrganization>Albums generally arranged by subject. Each album assigned a LOT number and photographs numbered within each LOT.</bf:materialOrganization>
+   </bf:Arrangement>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/index/13122894.ttl
+++ b/spec/fixtures/loc/m2b-properties/index/13122894.ttl
@@ -1,0 +1,1090 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix marcrelators: <http://id.loc.gov/vocabulary/relators/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/13122894annotation42> a bf:Annotation;
+   bf:annotates <http://example.org/13122894>;
+   bf:changeDate "2013-11-27T19:58";
+   bf:derivedFrom <http://example.org/13122894.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/gihc>,
+     <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/13122894helditem72> a bf:HeldItem;
+   bf:custodialHistory "Abdul-Hamid II (1842-1918), an avid collector and promoter of photography, appears to have conceived this collection as a portrait of his empire for a western audience. He presented a copy of the survey to the Library of Congress in 1893 or 1894. He also gave another almost identical collection to the British Museum (now in the British Library).";
+   bf:heldBy "Library of Congress";
+   bf:holdingFor <http://example.org/13122894instance43>;
+   bf:label "";
+   bf:subLocation "Prints and Photographs Division" .
+
+<http://example.org/13122894instance14> a bf:Instance;
+   bf:hdl <hdl.loc.gov/loc.pnp/pp.ahii>;
+   bf:instanceOf <http://example.org/13122894work10> .
+
+<http://example.org/13122894instance15> a bf:Instance;
+   bf:hdl <http://hdl.loc.gov/loc.gdc/lcoa1.about>;
+   bf:instanceOf <http://example.org/13122894work11> .
+
+<http://example.org/13122894instance44> a bf:Instance,
+     bf:Electronic;
+   bf:hdl <http://hdl.loc.gov/loc.pnp/pp.ahii>;
+   bf:instanceOf <http://example.org/13122894>;
+   bf:label "Electronic Resource" .
+
+<http://example.org/13122894summary12> a bf:Summary;
+   bf:annotationAssertedBy <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:annotationBody "These photographic albums portray the Ottoman Empire during the reign of one of its last sultans, Abdul-Hamid  II. They highlight the modernization of numerous aspects of the Ottoman Empire. Most of the places depicted are within the boundaries of modern-day Turkey, but buildings and sites in Iraq, Lebanon, Greece and other countries are also included. The images show students and educational facilities, including law, medical and military schools; well-equipped army and navy personnel and facilities; technologically advanced lifesaving and fire fighting brigades; factories; mines; harbors; hospitals; and government buildings. The     collection also documents historic Byzantine and Ottoman monuments, mosques, mosaics, fountains, palaces, and mausoleums, and includes panoramic landscapes and urban scenes. Other photographs depict Abdul Hamid's Yildiz Palace, yacht, and horses.";
+   bf:label "Summary";
+   bf:summaryOf <http://example.org/13122894> .
+
+<http://example.org/13122894arrangement70> a bf:Arrangement;
+   bf:materialOrganization "Albums generally arranged by subject. Each album assigned a LOT number and photographs numbered within each LOT." .
+
+<http://example.org/13122894instance43> a bf:Instance,
+     bf:Collection;
+   bf:accessCondition "Please use digital and print surrogates instead originals, following preservation policy.",
+     "Original albums; Restricted access: Materials extremely fragile;";
+   bf:arrangement <http://example.org/13122894arrangement70>;
+   bf:dimensions "32 x 19 in. or smaller.";
+   bf:extent "51 albums ;";
+   bf:formDesignation "graphic.";
+   bf:immediateAcquisition "Gift; Abdülhamid II; 1893-1894.";
+   bf:instanceOf <http://example.org/13122894>;
+   bf:instanceTitle <http://example.org/13122894title46>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2003652945"
+   ];
+   bf:modeOfIssuance "monographic";
+   bf:note "These photographic albums portray the Ottoman Empire during the reign of one of its last sultans, Abdul-Hamid  II. They highlight the modernization of numerous aspects of the Ottoman Empire. Most of the places depicted are within the boundaries of modern-day Turkey, but buildings and sites in Iraq, Lebanon, Greece and other countries are also included. The images show students and educational facilities, including law, medical and military schools; well-equipped army and navy personnel and facilities; technologically advanced lifesaving and fire fighting brigades; factories; mines; harbors; hospitals; and government buildings. The     collection also documents historic Byzantine and Ottoman monuments, mosques, mosaics, fountains, palaces, and mausoleums, and includes panoramic landscapes and urban scenes. Other photographs depict Abdul Hamid's Yildiz Palace, yacht, and horses.",
+     "Well-known Ottoman commercial photographers such as Abdullah Frères, Sebah & Joaillier, and Phèbus took the bulk of the photographs. Turkish military photographer Ali Rıza Pasa and the Photographic Unit of the Imperial School of Engineering also contributed numerous images.",
+     "No known restrictions on publication.",
+     "Collection title devised by Library staff.",
+     "Albums include four major subject categories: Category I: views, buildings, monuments and antiquities (LOTS 9515, 9516, 9517, 9518, 9523, 9524, 9528, 9529, 9532, 9533, 9534, 9535, 9541, 11907, 11910, 11912, 11913); Category II: military, naval, rescue services and military and industrial facilities (LOTS 9521, 9522, 9536, 9537, 9539, 9540, 9543, 9545, 11905, 11906, 11909, 11911, 11914, 11915, 11917, 11918, 11919); Category III: educational facilities (LOTS 9511, 9512, 9513, 9514, 9519, 9520, 9525, 9526, 9527, 9530, 9531, 9538, 9542, 9544, 11908); and Category IV: horses and imperial stables (LOTS 9546, 11916)",
+     "Photographs are chiefly albumen, some gelatin silver.",
+     "Black-and-white copy photographs are also available for reference purposes under LOT call numbers.",
+     "Digitized images of all items in the collection display with their associated catalog records in the Prints & Photographs Division Online Catalog,",
+     "Guide to the Special Collections of Prints & Photographs in the Library of Congress / compiled by Paul Vanderbilt. Washington, D.C. : 1955,",
+     "Special Collections in the Library of Congress / compiled by Annette Melville. Washington, D.C. : Library of Congress, 1980,",
+     "Abdul-Hamid II (1842-1918), an avid collector and promoter of photography, appears to have conceived this collection as a portrait of his empire for a western audience. He presented a copy of the survey to the Library of Congress in 1893 or 1894. He also gave another almost identical collection to the British Museum (now in the British Library).",
+     "Imperial self-portrait: The Ottoman Empire as revealed in the Sultan Abdul Hamid II's Photographic Albums. Edited by Carney E.S. Gavin and the Harvard Semitic Museum. Journal of Turkish Studies, v. 12, 1988. [Cambridge, Mass] : Harvard University, 1988.";
+   bf:providerStatement "1880-1893.";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "1880-1893"
+   ];
+   bf:titleStatement "Abdul-Hamid II collection of photographs of the Ottoman Empire" .
+
+<http://example.org/13122894organization7> a bf:Organization;
+   bf:authorizedAccessPoint "Abdullah frères";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Abdullah frères"
+   ];
+   bf:label "Abdullah frères" .
+
+<http://example.org/13122894organization8> a bf:Organization;
+   bf:authorizedAccessPoint "Sebah & Joaillier";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Sebah & Joaillier"
+   ];
+   bf:label "Sebah & Joaillier" .
+
+<http://example.org/13122894person13> a bf:Person;
+   bf:authorizedAccessPoint "Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects.";
+     mads:componentList ([
+         a mads:PersonalName,
+           mads:Authority;
+         mads:authoritativeLabel "Abdülhamid Sultan of the Turks, 1842-1918";
+         mads:elementList ([
+             a mads:FullNameElement;
+             mads:elementValue "Abdülhamid"
+           ] [
+             a mads:TermsOfAddressNameElement;
+             mads:elementValue "Sultan of the Turks,"
+           ] [
+             a mads:DateNameElement;
+             mads:elementValue "1842-1918"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Associated objects";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Associated objects."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <>
+   ];
+   bf:label "Abdülhamid II, Sultan of the Turks, 1842-1918--Associated objects." .
+
+<http://example.org/13122894person6> a bf:Person;
+   bf:authorizedAccessPoint "Abdülhamid II, Sultan of the Turks, 1842-1918";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Abdülhamid II, Sultan of the Turks, 1842-1918"
+   ];
+   bf:label "Abdülhamid II, Sultan of the Turks, 1842-1918" .
+
+<http://example.org/13122894title46> a bf:Title;
+   bf:label "Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].";
+   bf:titleValue "Abdul-Hamid II collection of photographs of the Ottoman Empire" .
+
+<http://example.org/13122894title5> a bf:Title;
+   bf:label "Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].";
+   bf:titleValue "Abdul-Hamid II collection of photographs of the Ottoman Empire" .
+
+<http://example.org/13122894topic14> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Government facilities--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Government facilities--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Government facilities";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Government facilities"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Government facilities--Turkey--1880-1900" .
+
+<http://example.org/13122894topic15> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Educational facilities--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Educational facilities--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Educational facilities";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Educational facilities"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Educational facilities--Turkey--1880-1900" .
+
+<http://example.org/13122894topic16> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Military facilities--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Military facilities--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Military facilities";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Military facilities"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Military facilities--Turkey--1880-1900" .
+
+<http://example.org/13122894topic17> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Lifesaving--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Lifesaving--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Lifesaving";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Lifesaving"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Lifesaving--Turkey--1880-1900" .
+
+<http://example.org/13122894topic18> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Students--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Students--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Students";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Students"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Students--Turkey--1880-1900" .
+
+<http://example.org/13122894topic19> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Mosaics--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Mosaics--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Mosaics";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Mosaics"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Mosaics--Turkey--1880-1900" .
+
+<http://example.org/13122894topic20> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Fountains--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Fountains--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Fountains";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Fountains"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Fountains--Turkey--1880-1900" .
+
+<http://example.org/13122894topic21> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Tombs & sepulchral monuments--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Tombs & sepulchral monuments--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Tombs & sepulchral monuments";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Tombs & sepulchral monuments"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Tombs & sepulchral monuments--Turkey--1880-1900" .
+
+<http://example.org/13122894topic22> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Horses--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Horses--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Horses";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Horses"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Horses--Turkey--1880-1900" .
+
+<http://example.org/13122894topic23> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Mosques--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Mosques--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Mosques";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Mosques"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Mosques--Turkey--1880-1900" .
+
+<http://example.org/13122894topic24> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Castles & palaces--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Castles & palaces--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Castles & palaces";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Castles & palaces"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Castles & palaces--Turkey--1880-1900" .
+
+<http://example.org/13122894topic25> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Hospitals--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Hospitals--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Hospitals";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Hospitals"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Hospitals--Turkey--1880-1900" .
+
+<http://example.org/13122894topic26> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Ships--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Ships--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Ships";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Ships"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Ships--Turkey--1880-1900" .
+
+<http://example.org/13122894topic27> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Fire fighting--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Fire fighting--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Fire fighting";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Fire fighting"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Fire fighting--Turkey--1880-1900" .
+
+<http://example.org/13122894topic28> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Forts & fortifications--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Forts & fortifications--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Forts & fortifications";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Forts & fortifications"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Forts & fortifications--Turkey--1880-1900" .
+
+<http://example.org/13122894topic29> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "City walls--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "City walls--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "City walls";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "City walls"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "City walls--Turkey--1880-1900" .
+
+<http://example.org/13122894topic30> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Yachts--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Yachts--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Yachts";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Yachts"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Yachts--Turkey--1880-1900" .
+
+<http://example.org/13122894topic31> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Factories--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Factories--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Factories";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Factories"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Factories--Turkey--1880-1900" .
+
+<http://example.org/13122894topic32> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Navies--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Navies--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Navies";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Navies"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Navies--Turkey--1880-1900" .
+
+<http://example.org/13122894topic33> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Military personnel--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Military personnel--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Military personnel";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Military personnel"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Military personnel--Turkey--1880-1900" .
+
+<http://example.org/13122894topic34> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lctgm";
+   bf:authorizedAccessPoint "Military life--Turkey--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Military life--Turkey--1880-1900";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Military life";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Military life"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Turkey";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Turkey"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lctgm>
+   ];
+   bf:label "Military life--Turkey--1880-1900" .
+
+<http://example.org/13122894topic35> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Cityscapes--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Cityscapes--1880-1900";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Cityscapes";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Cityscapes"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Cityscapes--1880-1900" .
+
+<http://example.org/13122894topic36> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Photograph albums--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Photograph albums--1880-1900";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Photograph albums";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Photograph albums"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Photograph albums--1880-1900" .
+
+<http://example.org/13122894topic37> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Portrait photographs--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Portrait photographs--1880-1900";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Portrait photographs";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Portrait photographs"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Portrait photographs--1880-1900" .
+
+<http://example.org/13122894topic38> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Group portraits--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Group portraits--1880-1900";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Group portraits";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Group portraits"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Group portraits--1880-1900" .
+
+<http://example.org/13122894topic39> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/gmgpc";
+   bf:authorizedAccessPoint "Albumen prints--1880-1900";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Albumen prints--1880-1900";
+     mads:componentList ([
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Albumen prints";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Albumen prints"
+           ])
+       ] [
+         a mads:Temporal,
+           mads:Authority;
+         mads:authoritativeLabel "1880-1900";
+         mads:elementList ([
+             a mads:TemporalElement;
+             mads:elementValue "1880-1900."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/gmgpc>
+   ];
+   bf:label "Albumen prints--1880-1900" .
+
+<http://example.org/13122894work10> a bf:Work;
+   bf:authorizedAccessPoint "Collection profile available online";
+   bf:title "Collection profile available online" .
+
+<http://example.org/13122894work11> a bf:Work;
+   bf:authorizedAccessPoint "A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See";
+   bf:title "A set of catalog records describing each item is available through the Open Archives Initiative Protocol for Metadata Harvesting. See" .
+
+<http://example.org/13122894> a bf:Work,
+     bf:StillImage;
+   bf:authorizedAccessPoint "Abdülhamid II, Sultan of the Turks, 1842-1918 Abdul-Hamid II collection of photographs of the Ottoman Empire [graphic].Abdul-Hamid II collection of photographs of the Ottoman Empire",
+     "abdülhamidiisultanoftheturks18421918abdullahfrèressebahjoaillierabdulhamidiicollectionofphotographsoftheottomanempireotaworkstillimage"@x-bf-hash;
+   bf:index <http://example.org/13122894work10>,
+     <http://example.org/13122894work11>;
+   bf:language <http://id.loc.gov/vocabulary/languages/ota>;
+   bf:subject <http://example.org/13122894person13>,
+     <http://example.org/13122894topic14>,
+     <http://example.org/13122894topic15>,
+     <http://example.org/13122894topic16>,
+     <http://example.org/13122894topic17>,
+     <http://example.org/13122894topic18>,
+     <http://example.org/13122894topic19>,
+     <http://example.org/13122894topic20>,
+     <http://example.org/13122894topic21>,
+     <http://example.org/13122894topic22>,
+     <http://example.org/13122894topic23>,
+     <http://example.org/13122894topic24>,
+     <http://example.org/13122894topic25>,
+     <http://example.org/13122894topic26>,
+     <http://example.org/13122894topic27>,
+     <http://example.org/13122894topic28>,
+     <http://example.org/13122894topic29>,
+     <http://example.org/13122894topic30>,
+     <http://example.org/13122894topic31>,
+     <http://example.org/13122894topic32>,
+     <http://example.org/13122894topic33>,
+     <http://example.org/13122894topic34>,
+     <http://example.org/13122894topic35>,
+     <http://example.org/13122894topic36>,
+     <http://example.org/13122894topic37>,
+     <http://example.org/13122894topic38>,
+     <http://example.org/13122894topic39>,
+     <http://id.loc.gov/vocabulary/geographicAreas/a-tu>;
+   bf:workTitle <http://example.org/13122894title5>;
+   marcrelators:dnr <http://example.org/13122894person6>;
+   marcrelators:pht <http://example.org/13122894organization7>,
+     <http://example.org/13122894organization8> .

--- a/spec/fixtures/loc/m2b-properties/instanceOf/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/instanceOf/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/instanceTitle/5808761.marcxml
+++ b/spec/fixtures/loc/m2b-properties/instanceTitle/5808761.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01619cpcaa2200361   4500</leader>
   <controlfield tag="001">5808761</controlfield>
   <controlfield tag="005">20120329155857.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">MSS.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5808761</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/intendedAudience/16484626.marcxml
+++ b/spec/fixtures/loc/m2b-properties/intendedAudience/16484626.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01659cam a2200361 a 4500</leader>
   <controlfield tag="001">16484626</controlfield>
   <controlfield tag="005">20110819150237.0</controlfield>
@@ -110,4 +110,4 @@
     <subfield code="z">United States</subfield>
     <subfield code="v">Juvenile literature.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16484626</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/intendedAudience/4889062.marcxml
+++ b/spec/fixtures/loc/m2b-properties/intendedAudience/4889062.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01210pam a2200361 a 4500</leader>
   <controlfield tag="001">4889062</controlfield>
   <controlfield tag="005">19960326081351.5</controlfield>
@@ -102,4 +102,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4889062</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isan/17332794.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isan/17332794.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01097cgm a22003135a 4500</leader>
   <controlfield tag="001">17332794</controlfield>
   <controlfield tag="005">20120605144630.0</controlfield>
@@ -83,4 +83,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">Nacionalni ansambl Kolo.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17332794</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn/16373436.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn/16373436.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>05907cam a2200385 a 4500</leader>
   <controlfield tag="001">16373436</controlfield>
   <controlfield tag="005">20110124142733.0</controlfield>
@@ -119,4 +119,4 @@
     <subfield code="3">Cover image</subfield>
     <subfield code="u">http://assets.cambridge.org/97811070/00421/cover/9781107000421.jpg</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16373436</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn/17082740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn/17082740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01863cam a2200385 a 4500</leader>
   <controlfield tag="001">17082740</controlfield>
   <controlfield tag="005">20120215113723.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1205/2011276039-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17082740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn10/16373436.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn10/16373436.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>05907cam a2200385 a 4500</leader>
   <controlfield tag="001">16373436</controlfield>
   <controlfield tag="005">20110124142733.0</controlfield>
@@ -119,4 +119,4 @@
     <subfield code="3">Cover image</subfield>
     <subfield code="u">http://assets.cambridge.org/97811070/00421/cover/9781107000421.jpg</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16373436</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn10/17082740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn10/17082740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01863cam a2200385 a 4500</leader>
   <controlfield tag="001">17082740</controlfield>
   <controlfield tag="005">20120215113723.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1205/2011276039-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17082740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn13/16373436.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn13/16373436.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>05907cam a2200385 a 4500</leader>
   <controlfield tag="001">16373436</controlfield>
   <controlfield tag="005">20110124142733.0</controlfield>
@@ -119,4 +119,4 @@
     <subfield code="3">Cover image</subfield>
     <subfield code="u">http://assets.cambridge.org/97811070/00421/cover/9781107000421.jpg</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16373436</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isbn13/17082740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isbn13/17082740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01863cam a2200385 a 4500</leader>
   <controlfield tag="001">17082740</controlfield>
   <controlfield tag="005">20120215113723.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="3">Table of contents only</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1205/2011276039-t.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17082740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/ismn/12982553.marcxml
+++ b/spec/fixtures/loc/m2b-properties/ismn/12982553.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01226ccm a2200325 a 4500</leader>
   <controlfield tag="001">12982553</controlfield>
   <controlfield tag="005">20080602145117.0</controlfield>
@@ -96,4 +96,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12982553</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/iso/7834399.marcxml
+++ b/spec/fixtures/loc/m2b-properties/iso/7834399.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00994cam a22002891  4500</leader>
   <controlfield tag="001">7834399</controlfield>
   <controlfield tag="005">20050801183041.0</controlfield>
@@ -81,4 +81,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=7834399</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/isrc/14186870.marcxml
+++ b/spec/fixtures/loc/m2b-properties/isrc/14186870.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02469cam a2200445 a 4500</leader>
   <controlfield tag="001">14186870</controlfield>
   <controlfield tag="005">20130531081029.0</controlfield>
@@ -145,4 +145,4 @@
     <subfield code="6">740-08/(2/r</subfield>
     <subfield code="a">&#x5E9;&#x5E2;&#x5E8; &#x5D4;&#x5DB;&#x5D5;&#x5D5;&#x5E0;&#x5D5;&#x5EA;.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14186870</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/issn/17387996.marcxml
+++ b/spec/fixtures/loc/m2b-properties/issn/17387996.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01727cas a2200409 i 4500</leader>
   <controlfield tag="001">17387996</controlfield>
   <controlfield tag="005">20140814075250.0</controlfield>
@@ -128,4 +128,4 @@
   <datafield tag="963" ind1=" " ind2=" ">
     <subfield code="a">huang@untestedideas.org</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17387996</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/issnL/11187857.marcxml
+++ b/spec/fixtures/loc/m2b-properties/issnL/11187857.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02911cas a2200685 a 4500</leader>
   <controlfield tag="001">11187857</controlfield>
   <controlfield tag="005">20140912075312.0</controlfield>
@@ -238,4 +238,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11187857</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/issueNumber/12241297.marcxml
+++ b/spec/fixtures/loc/m2b-properties/issueNumber/12241297.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01873cjm a22003731a 4500</leader>
   <controlfield tag="001">12241297</controlfield>
   <controlfield tag="005">20121019141547.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">srreplace 2003-01</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12241297</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/issuedWith/11331701.marcxml
+++ b/spec/fixtures/loc/m2b-properties/issuedWith/11331701.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02308cas a2200541 a 4500</leader>
   <controlfield tag="001">11331701</controlfield>
   <controlfield tag="005">20121213081215.0</controlfield>
@@ -168,4 +168,4 @@
     <subfield code="b">SER</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11331701</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/itemId/5572592.marcxml
+++ b/spec/fixtures/loc/m2b-properties/itemId/5572592.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01733cem a2200373 a 4500</leader>
   <controlfield tag="001">5572592</controlfield>
   <controlfield tag="005">19980922153159.4</controlfield>
@@ -108,4 +108,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5572592</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/keyTitle/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/keyTitle/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/keyTitle/11181371.marcxml
+++ b/spec/fixtures/loc/m2b-properties/keyTitle/11181371.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01148cas a2200385   4500</leader>
   <controlfield tag="001">11181371</controlfield>
   <controlfield tag="005">20130425081253.0</controlfield>
@@ -113,4 +113,4 @@
     <subfield code="b">LLK</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11181371</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/label/11185095.marcxml
+++ b/spec/fixtures/loc/m2b-properties/label/11185095.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02048cas a2200457 a 4500</leader>
   <controlfield tag="001">11185095</controlfield>
   <controlfield tag="005">20121213075511.0</controlfield>
@@ -144,4 +144,4 @@
     <subfield code="b">B/L</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11185095</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/language/16241964.marcxml
+++ b/spec/fixtures/loc/m2b-properties/language/16241964.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02603ccm a22005294a 4500</leader>
   <controlfield tag="001">16241964</controlfield>
   <controlfield tag="005">20130606100858.0</controlfield>
@@ -192,4 +192,4 @@
     <subfield code="a">Recent researches in the music of the nineteenth and early twentieth centuries ;</subfield>
     <subfield code="v">v. 44.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16241964</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/language/5485844.marcxml
+++ b/spec/fixtures/loc/m2b-properties/language/5485844.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01635cem a2200385 a 4500</leader>
   <controlfield tag="001">5485844</controlfield>
   <controlfield tag="005">20130501114526.0</controlfield>
@@ -114,4 +114,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5485844</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/languageNote/15747233.marcxml
+++ b/spec/fixtures/loc/m2b-properties/languageNote/15747233.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03116cam a2200493 a 4500</leader>
   <controlfield tag="001">15747233</controlfield>
   <controlfield tag="005">20140822162057.0</controlfield>
@@ -225,4 +225,4 @@
   <datafield tag="830" ind1=" " ind2="0">
     <subfield code="a">Classical texts.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15747233</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/languageOfPartUri/12076972.marcxml
+++ b/spec/fixtures/loc/m2b-properties/languageOfPartUri/12076972.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01747cjm a22003731a 4500</leader>
   <controlfield tag="001">12076972</controlfield>
   <controlfield tag="005">20000624075139.0</controlfield>
@@ -104,4 +104,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">Claimed Recordings</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12076972</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/lcOverseasAcq/12402887.marcxml
+++ b/spec/fixtures/loc/m2b-properties/lcOverseasAcq/12402887.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01227cam a2200313 a 4500</leader>
   <controlfield tag="001">12402887</controlfield>
   <controlfield tag="005">20020312135428.0</controlfield>
@@ -92,4 +92,4 @@
     <subfield code="o">am</subfield>
     <subfield code="p">00071040768</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12402887</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/lccn/3033870.marcxml
+++ b/spec/fixtures/loc/m2b-properties/lccn/3033870.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01809pam a2200361 a 4500</leader>
   <controlfield tag="001">3033870</controlfield>
   <controlfield tag="005">20100818141649.0</controlfield>
@@ -117,4 +117,4 @@
     <subfield code="m">Biog</subfield>
     <subfield code="w">GenBib bi 97-000526</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3033870</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/legalDate/6872697.marcxml
+++ b/spec/fixtures/loc/m2b-properties/legalDate/6872697.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00906cam a2200217u  4500</leader>
   <controlfield tag="001">6872697</controlfield>
   <controlfield tag="005">20090107145736.0</controlfield>
@@ -63,4 +63,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=6872697</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/legalDeposit/11510969.marcxml
+++ b/spec/fixtures/loc/m2b-properties/legalDeposit/11510969.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>06686cgm a2201249 a 4500</leader>
   <controlfield tag="001">11510969</controlfield>
   <controlfield tag="005">20140812152343.0</controlfield>
@@ -407,4 +407,4 @@
     <subfield code="h">CQA 0534-0546 (neg trk)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11510969</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/legalDeposit/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/legalDeposit/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/manufacture/12598166.marcxml
+++ b/spec/fixtures/loc/m2b-properties/manufacture/12598166.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01234cam a22003374a 4500</leader>
   <controlfield tag="001">12598166</controlfield>
   <controlfield tag="005">20030307161917.0</controlfield>
@@ -103,4 +103,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12598166</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/manufacture/1656924.marcxml
+++ b/spec/fixtures/loc/m2b-properties/manufacture/1656924.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00755nam a22002057a 4500</leader>
   <controlfield tag="001">1656924</controlfield>
   <controlfield tag="005">19971027145741.0</controlfield>
@@ -57,4 +57,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=1656924</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/manufacture/3235758.marcxml
+++ b/spec/fixtures/loc/m2b-properties/manufacture/3235758.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00638nam a2200205 i 4500</leader>
   <controlfield tag="001">3235758</controlfield>
   <controlfield tag="005">19790612000000.0</controlfield>
@@ -62,4 +62,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3235758</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/materialArrangement/11628622.marcxml
+++ b/spec/fixtures/loc/m2b-properties/materialArrangement/11628622.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>07792ckc a2201081 a 4500</leader>
   <controlfield tag="001">11628622</controlfield>
   <controlfield tag="005">20150626082430.0</controlfield>
@@ -386,4 +386,4 @@
     <subfield code="v">obj.</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11628622</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/materialOrganization/16530652.marcxml
+++ b/spec/fixtures/loc/m2b-properties/materialOrganization/16530652.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03995ckd a2200637 a 4500</leader>
   <controlfield tag="001">16530652</controlfield>
   <controlfield tag="005">20110616095858.0</controlfield>
@@ -212,4 +212,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="m">(H)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16530652</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/materialPart/14747204.marcxml
+++ b/spec/fixtures/loc/m2b-properties/materialPart/14747204.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04370ckc a2200397 a 4500</leader>
   <controlfield tag="001">14747204</controlfield>
   <controlfield tag="005">20101210145356.0</controlfield>
@@ -119,4 +119,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="v">obj.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14747204</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/mediaCategory/16088242.marcxml
+++ b/spec/fixtures/loc/m2b-properties/mediaCategory/16088242.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01348cam a2200313 i 4500</leader>
   <controlfield tag="001">16088242</controlfield>
   <controlfield tag="005">20101028100525.0</controlfield>
@@ -94,4 +94,4 @@
   <datafield tag="710" ind1="2" ind2=" ">
     <subfield code="a">Mingei International Museum.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16088242</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/modeOfIssuance/5226.marcxml
+++ b/spec/fixtures/loc/m2b-properties/modeOfIssuance/5226.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01035cam a2200325 a 4500</leader>
   <controlfield tag="001">5226</controlfield>
   <controlfield tag="005">20081223095049.0</controlfield>

--- a/spec/fixtures/loc/m2b-properties/musicKey/12220729.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicKey/12220729.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01365cjm a22003494a 4500</leader>
   <controlfield tag="001">12220729</controlfield>
   <controlfield tag="005">20130524121048.0</controlfield>
@@ -105,4 +105,4 @@
     <subfield code="a">Chicago Symphony Orchestra.</subfield>
     <subfield code="4">prf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12220729</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicMediumNote/5582683.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicMediumNote/5582683.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01112ccm a2200301 a 4500</leader>
   <controlfield tag="001">5582683</controlfield>
   <controlfield tag="005">20060713134455.0</controlfield>
@@ -87,4 +87,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5582683</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicNumber/14405357.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicNumber/14405357.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01605cim a22003497a 4500</leader>
   <controlfield tag="001">14405357</controlfield>
   <controlfield tag="005">20111221121124.0</controlfield>
@@ -96,4 +96,4 @@
   <datafield tag="740" ind1="0" ind2="2">
     <subfield code="a">Averell Harriman meets the press.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14405357</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicPlate/12863283.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicPlate/12863283.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01155ccm a22003254a 4500</leader>
   <controlfield tag="001">12863283</controlfield>
   <controlfield tag="005">20130410064101.0</controlfield>
@@ -95,4 +95,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12863283</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicPlate/5639219.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicPlate/5639219.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00909ccm a2200265 a 4500</leader>
   <controlfield tag="001">5639219</controlfield>
   <controlfield tag="005">20060308165413.0</controlfield>
@@ -77,4 +77,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5639219</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicPublisherNumber/15532740.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicPublisherNumber/15532740.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01218ccm a2200361 a 4500</leader>
   <controlfield tag="001">15532740</controlfield>
   <controlfield tag="005">20090205092213.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="955" ind1=" " ind2=" ">
     <subfield code="a">fd09 2008-11-24 z-processor</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15532740</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicVersion/3424680.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicVersion/3424680.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01374ctm a2200361 a 4500</leader>
   <controlfield tag="001">3424680</controlfield>
   <controlfield tag="005">20130417121318.0</controlfield>
@@ -106,4 +106,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3424680</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/musicVersion/5591972.marcxml
+++ b/spec/fixtures/loc/m2b-properties/musicVersion/5591972.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01087ccm a2200301 a 4500</leader>
   <controlfield tag="001">5591972</controlfield>
   <controlfield tag="005">20130501140338.0</controlfield>
@@ -88,4 +88,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MUSIC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5591972</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/nban/15507796.marcxml
+++ b/spec/fixtures/loc/m2b-properties/nban/15507796.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01478cam a22003857a 4500</leader>
   <controlfield tag="001">15507796</controlfield>
   <controlfield tag="005">20090811181452.0</controlfield>
@@ -120,4 +120,4 @@
     <subfield code="a">Silverman, Dan,</subfield>
     <subfield code="d">1956-</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15507796</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/nbn/6661472.marcxml
+++ b/spec/fixtures/loc/m2b-properties/nbn/6661472.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01033cam a22002771i 4500</leader>
   <controlfield tag="001">6661472</controlfield>
   <controlfield tag="005">20131024102609.0</controlfield>
@@ -81,4 +81,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=6661472</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/notation/15922216.marcxml
+++ b/spec/fixtures/loc/m2b-properties/notation/15922216.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00782cam a22002177a 4500</leader>
   <controlfield tag="001">15922216</controlfield>
   <controlfield tag="005">20100311123823.0</controlfield>
@@ -64,4 +64,4 @@
     <subfield code="n">*</subfield>
     <subfield code="s">*</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15922216</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/note/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-properties/note/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/note/12983758.marcxml
+++ b/spec/fixtures/loc/m2b-properties/note/12983758.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03385ckm a22004817a 4500</leader>
   <controlfield tag="001">12983758</controlfield>
   <controlfield tag="005">20140703110534.0</controlfield>
@@ -153,4 +153,4 @@
     <subfield code="m">(D size)</subfield>
     <subfield code="v">obj.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12983758</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/originDate/14507819.marcxml
+++ b/spec/fixtures/loc/m2b-properties/originDate/14507819.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01514cam a2200337 a 4500</leader>
   <controlfield tag="001">14507819</controlfield>
   <controlfield tag="005">20130531115630.0</controlfield>
@@ -115,4 +115,4 @@
     <subfield code="6">730-05/(2/r</subfield>
     <subfield code="a">&#x5EA;&#x5DB;&#x5DC;&#x5EA; &#x5D0;&#x5D1;&#x5E8;&#x5D4;&#x5DD;.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14507819</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/originDate/5217778.marcxml
+++ b/spec/fixtures/loc/m2b-properties/originDate/5217778.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03125cam a2200625 a 4500</leader>
   <controlfield tag="001">5217778</controlfield>
   <controlfield tag="005">20130430133402.0</controlfield>
@@ -222,4 +222,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5217778</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/originalVersion/14342057.marcxml
+++ b/spec/fixtures/loc/m2b-properties/originalVersion/14342057.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01711cam a22003614a 4500</leader>
   <controlfield tag="001">14342057</controlfield>
   <controlfield tag="005">20080707172353.0</controlfield>
@@ -114,4 +114,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14342057</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/originalVersion/14342057.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/originalVersion/14342057.rdfxml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/14342057">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Caesar, Julius. Works. 2003</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Works. 2003</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/14342057title6"/>
+      <bf:creator rdf:resource="http://example.org/14342057person7"/>
+      <bf:contributor rdf:resource="http://example.org/14342057person8"/>
+      <bf:contributor rdf:resource="http://example.org/14342057person9"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/fre"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/lat"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/fre"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/e"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/ff"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/aw"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/PA6235"/>
+      <bf:originalVersion rdf:resource="http://example.org/14342057work17"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">caesarjuliusmontaignemichelde15331592galletandréworks2003freworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14342057work17">
+      <bf:title>C. Iulii Caesaris Commentarii, novis emendationibus illustrati</bf:title>
+      <bf:authorizedAccessPoint>C. Iulii Caesaris Commentarii, novis emendationibus illustrati</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/14342057instance20">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/14342057title23"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/2841031276"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9782841031276"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Musée Condé </bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Chantilly </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:copyrightDate>c2002.</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>William Blake &amp; Co. </bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Bordeaux </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:copyrightDate>c2002.</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>2 v. :</bf:extent>
+      <bf:dimensions>23 cm.</bf:dimensions>
+      <bf:illustrationNote>ill., maps ;</bf:illustrationNote>
+      <bf:titleStatement>"Somme, c'est César--" : première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne</bf:titleStatement>
+      <bf:providerStatement>Chantilly : Musée Condé ; Bordeaux : William Blake &amp; Co. ; c2002.</bf:providerStatement>
+      <bf:languageNote>In Latin; introductory matters and marginal notes in French.</bf:languageNote>
+      <bf:supplementaryContentNote>Includes bibliographical references.</bf:supplementaryContentNote>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2006464780</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>(CStRLIN)NJPGV4078532-B</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/systemNumber"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>(NjP)4078532</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/systemNumber"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:instanceOf rdf:resource="http://example.org/14342057"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/14342057annotation19">
+      <bf:derivedFrom rdf:resource="http://example.org/14342057.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/frpjt"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/njp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2008-07-07T17:23</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/14342057"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/14342057helditem40">
+      <bf:label>PA6235 .A2 2002</bf:label>
+      <bf:shelfMarkLcc>PA6235 .A2 2002</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/14342057instance20"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/14342057title6">
+      <bf:titleValue>Works.</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/14342057person7">
+      <bf:label>Caesar, Julius.</bf:label>
+      <bf:authorizedAccessPoint>Caesar, Julius.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Caesar, Julius.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14342057person8">
+      <bf:label>Montaigne, Michel de, 1533-1592.</bf:label>
+      <bf:authorizedAccessPoint>Montaigne, Michel de, 1533-1592.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Montaigne, Michel de, 1533-1592.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/14342057person9">
+      <bf:label>Gallet, André.</bf:label>
+      <bf:authorizedAccessPoint>Gallet, André.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Gallet, André.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Title rdf:about="http://example.org/14342057title23">
+      <bf:label>"Somme, c'est César--" : première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne / Michel de Montaigne ; publié par André Gallet ; avec une introduction par André Gallet ; une notice bibliographique de Francis Pottiée-Sperry ; et une note historique par Emmanuelle Toulet.</bf:label>
+      <bf:titleValue>"Somme, c'est César--" :</bf:titleValue>
+      <bf:subtitle>première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne </bf:subtitle>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/originalVersion/14342057.ttl
+++ b/spec/fixtures/loc/m2b-properties/originalVersion/14342057.ttl
@@ -1,0 +1,126 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/14342057annotation19> a bf:Annotation;
+   bf:annotates <http://example.org/14342057>;
+   bf:changeDate "2008-07-07T17:23";
+   bf:derivedFrom <http://example.org/14342057.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/njp>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/frpjt>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/14342057helditem40> a bf:HeldItem;
+   bf:holdingFor <http://example.org/14342057instance20>;
+   bf:label "PA6235 .A2 2002";
+   bf:shelfMarkLcc "PA6235 .A2 2002" .
+
+<http://example.org/14342057instance20> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "23 cm.";
+   bf:extent "2 v. :";
+   bf:illustrationNote "ill., maps ;";
+   bf:instanceOf <http://example.org/14342057>;
+   bf:instanceTitle <http://example.org/14342057title23>;
+   bf:isbn10 <http://isbn.example.org/2841031276>;
+   bf:isbn13 <http://isbn.example.org/9782841031276>;
+   bf:languageNote "In Latin; introductory matters and marginal notes in French.";
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2006464780"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:providerStatement "Chantilly : Musée Condé ; Bordeaux : William Blake & Co. ; c2002.";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "c2002.";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Musée Condé "
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Chantilly "
+     ]
+   ],  [
+     a bf:Provider;
+     bf:copyrightDate "c2002.";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "William Blake & Co. "
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Bordeaux "
+     ]
+   ];
+   bf:supplementaryContentNote "Includes bibliographical references.";
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:systemNumber;
+     bf:identifierValue "(CStRLIN)NJPGV4078532-B"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:systemNumber;
+     bf:identifierValue "(NjP)4078532"
+   ];
+   bf:titleStatement "\"Somme, c'est César--\" : première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne" .
+
+<http://example.org/14342057person7> a bf:Person;
+   bf:authorizedAccessPoint "Caesar, Julius.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Caesar, Julius."
+   ];
+   bf:label "Caesar, Julius." .
+
+<http://example.org/14342057person8> a bf:Person;
+   bf:authorizedAccessPoint "Montaigne, Michel de, 1533-1592.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Montaigne, Michel de, 1533-1592."
+   ];
+   bf:label "Montaigne, Michel de, 1533-1592." .
+
+<http://example.org/14342057person9> a bf:Person;
+   bf:authorizedAccessPoint "Gallet, André.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Gallet, André."
+   ];
+   bf:label "Gallet, André." .
+
+<http://example.org/14342057title23> a bf:Title;
+   bf:label "\"Somme, c'est César--\" : première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne / Michel de Montaigne ; publié par André Gallet ; avec une introduction par André Gallet ; une notice bibliographique de Francis Pottiée-Sperry ; et une note historique par Emmanuelle Toulet.";
+   bf:subtitle "première reproduction, en fac-simile, de l'exemplaire des Commentaires de César, annoté par Montaigne ";
+   bf:titleValue "\"Somme, c'est César--\" :" .
+
+<http://example.org/14342057title6> a bf:Title;
+   bf:titleValue "Works." .
+
+<http://example.org/14342057work17> a bf:Work;
+   bf:authorizedAccessPoint "C. Iulii Caesaris Commentarii, novis emendationibus illustrati";
+   bf:title "C. Iulii Caesaris Commentarii, novis emendationibus illustrati" .
+
+<http://example.org/14342057> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Caesar, Julius. Works. 2003",
+     "caesarjuliusmontaignemichelde15331592galletandréworks2003freworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/PA6235>;
+   bf:contributor <http://example.org/14342057person8>,
+     <http://example.org/14342057person9>;
+   bf:creator <http://example.org/14342057person7>;
+   bf:language <http://id.loc.gov/vocabulary/languages/fre>,
+     <http://id.loc.gov/vocabulary/languages/lat>;
+   bf:originalVersion <http://example.org/14342057work17>;
+   bf:subject <http://id.loc.gov/vocabulary/geographicAreas/e>,
+     <http://id.loc.gov/vocabulary/geographicAreas/ff>,
+     <http://id.loc.gov/vocabulary/geographicAreas/aw>;
+   bf:workTitle <http://example.org/14342057title6>;
+   mads:authoritativeLabel "Works. 2003" .

--- a/spec/fixtures/loc/m2b-properties/otherEdition/11346685.marcxml
+++ b/spec/fixtures/loc/m2b-properties/otherEdition/11346685.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01830cas a2200481 a 4500</leader>
   <controlfield tag="001">11346685</controlfield>
   <controlfield tag="005">20130303163042.0</controlfield>
@@ -163,4 +163,4 @@
     <subfield code="b">MUS</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11346685</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/otherEdition/11346685.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/otherEdition/11346685.rdfxml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11346685">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Home &amp; studio recording.Home &amp; studio recording</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11346685title5"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11346685topic8"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/TK7881.4"/>
+      <bf:classification rdf:resource="http://example.org/11346685classification10"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:absorbed rdf:resource="http://example.org/11346685work12"/>
+      <bf:continuedBy rdf:resource="http://example.org/11346685work13"/>
+      <bf:otherEdition rdf:resource="http://example.org/11346685work14"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">homestudiorecordingengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work12">
+      <bf:title>Music technology</bf:title>
+      <bf:authorizedAccessPoint>Music technology</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0896-2480"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn87033459"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/16461726"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work13">
+      <bf:title>Recording</bf:title>
+      <bf:authorizedAccessPoint>Recording</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1078-8352"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/94642153"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/31020245"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11346685work14">
+      <bf:title>Home &amp; studio recording (Spanish ed.)</bf:title>
+      <bf:authorizedAccessPoint>Home &amp; studio recording (Spanish ed.)</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1074-2050"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn94000149"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11346685instance17">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11346685title20"/>
+      <bf:keyTitle rdf:resource="http://example.org/11346685title21"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11346685title22"/>
+      <bf:titleVariation rdf:resource="http://example.org/11346685title23"/>
+      <bf:titleVariation rdf:resource="http://example.org/11346685title24"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Music Maker Publications</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Canoga Park, CA </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>-c1994</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. (some col.) ;</bf:illustrationNote>
+      <bf:titleStatement>Home &amp; studio recording.</bf:titleStatement>
+      <bf:providerStatement>Canoga Park, CA : Music Maker Publications, -c1994.</bf:providerStatement>
+      <bf:frequencyNote>Monthly</bf:frequencyNote>
+      <bf:note>Issues for &lt;June 1988-&gt; published: Chatsworth, CA.</bf:note>
+      <bf:note>Also issued in Spanish.</bf:note>
+      <bf:note>Description based on: Vol. 3, no. 8 (June 1990); title from cover.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>88651318</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+            <bf:identifierValue>sn 87007375</bf:identifierValue>
+            <bf:identifierStatus>canceled/invalid</bf:identifierStatus>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>0896-7172</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:postalRegistration>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/postalRegistration"/>
+            <bf:identifierValue>002298</bf:identifierValue>
+            <bf:identifierAssigner>USPS</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:postalRegistration>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/17285024"/>
+      <bf:stockNumber>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/stockNumber"/>
+            <bf:identifierAssigner>Music Maker Publications, Inc., 21601 Devonshire St., Suite 212, Chatsworth, CA 91311</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:stockNumber>
+      <bf:serialLastIssue>v. 7, no. 9 (June 1994).</bf:serialLastIssue>
+      <bf:serialFirstIssue>Began in 1987.</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11346685"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11346685annotation16">
+      <bf:derivedFrom rdf:resource="http://example.org/11346685.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/clu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nic"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mwwf"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-03-03T16:30</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11346685"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11346685helditem46">
+      <bf:label>TK7881.4 .H65</bf:label>
+      <bf:shelfMarkLcc>TK7881.4 .H65</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11346685instance17"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11346685title5">
+      <bf:label>Home &amp; studio recording.</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Topic rdf:about="http://example.org/11346685topic8">
+      <bf:authorizedAccessPoint>Sound--Recording and reproducing--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Sound--Recording and reproducing--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Sound--Recording and reproducing--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Sound</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Sound</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Recording and reproducing</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Recording and reproducing</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11346685classification10">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>621.389/3</bf:classificationNumber>
+      <bf:label>621.389/3</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>19</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/11346685title20">
+      <bf:label>Home stud. rec.</bf:label>
+      <bf:titleValue>Home stud. rec.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title21">
+      <bf:label>Home &amp; studio recording</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title22">
+      <bf:label>Home &amp; studio recording.</bf:label>
+      <bf:titleValue>Home &amp; studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title23">
+      <bf:titleType>portion</bf:titleType>
+      <bf:label>Home and studio recording</bf:label>
+      <bf:titleValue>Home and studio recording</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11346685title24">
+      <bf:titleType>running</bf:titleType>
+      <bf:label>H &amp; SR</bf:label>
+      <bf:titleValue>H &amp; SR</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/otherEdition/11346685.ttl
+++ b/spec/fixtures/loc/m2b-properties/otherEdition/11346685.ttl
@@ -1,0 +1,201 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11346685annotation16> a bf:Annotation;
+   bf:annotates <http://example.org/11346685>;
+   bf:changeDate "2013-03-03T16:30";
+   bf:derivedFrom <http://example.org/11346685.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nsdp>,
+     <http://id.loc.gov/vocabulary/organizations/clu>,
+     <http://id.loc.gov/vocabulary/organizations/nic>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/mwwf>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/nsdp>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11346685helditem46> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11346685instance17>;
+   bf:label "TK7881.4 .H65";
+   bf:shelfMarkLcc "TK7881.4 .H65" .
+
+<http://example.org/11346685classification10> a bf:Classification;
+   bf:classificationEdition "full",
+     "19";
+   bf:classificationNumber "621.389/3";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "621.389/3" .
+
+<http://example.org/11346685instance17> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11346685title20>;
+   bf:dimensions "28 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Monthly";
+   bf:illustrationNote "ill. (some col.) ;";
+   bf:instanceOf <http://example.org/11346685>;
+   bf:instanceTitle <http://example.org/11346685title22>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "0896-7172"
+   ];
+   bf:keyTitle <http://example.org/11346685title21>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "88651318"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierStatus "canceled/invalid";
+     bf:identifierValue "sn 87007375"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Issues for <June 1988-> published: Chatsworth, CA.",
+     "Also issued in Spanish.",
+     "Description based on: Vol. 3, no. 8 (June 1990); title from cover.",
+     "SERBIB/SERLOC merged record";
+   bf:postalRegistration [
+     a bf:Identifier;
+     bf:identifierAssigner "USPS";
+     bf:identifierScheme loc_ids:postalRegistration;
+     bf:identifierValue "002298"
+   ];
+   bf:providerStatement "Canoga Park, CA : Music Maker Publications, -c1994.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "-c1994";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Music Maker Publications"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Canoga Park, CA "
+     ]
+   ];
+   bf:serialFirstIssue "Began in 1987.";
+   bf:serialLastIssue "v. 7, no. 9 (June 1994).";
+   bf:stockNumber [
+     a bf:Identifier;
+     bf:identifierAssigner "Music Maker Publications, Inc., 21601 Devonshire St., Suite 212, Chatsworth, CA 91311";
+     bf:identifierScheme loc_ids:stockNumber
+   ];
+   bf:systemNumber <http://www.worldcat.org/oclc/17285024>;
+   bf:titleStatement "Home & studio recording.";
+   bf:titleVariation <http://example.org/11346685title23>,
+     <http://example.org/11346685title24> .
+
+<http://example.org/11346685title20> a bf:Title;
+   bf:label "Home stud. rec.";
+   bf:titleValue "Home stud. rec." .
+
+<http://example.org/11346685title21> a bf:Title;
+   bf:label "Home & studio recording";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685title22> a bf:Title;
+   bf:label "Home & studio recording.";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685title23> a bf:Title;
+   bf:label "Home and studio recording";
+   bf:titleType "portion";
+   bf:titleValue "Home and studio recording" .
+
+<http://example.org/11346685title24> a bf:Title;
+   bf:label "H & SR";
+   bf:titleType "running";
+   bf:titleValue "H & SR" .
+
+<http://example.org/11346685title5> a bf:Title;
+   bf:label "Home & studio recording.";
+   bf:titleValue "Home & studio recording" .
+
+<http://example.org/11346685topic8> a bf:Topic;
+   bf:authorizedAccessPoint "Sound--Recording and reproducing--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Sound--Recording and reproducing--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Sound";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Sound"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Recording and reproducing";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Recording and reproducing"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Sound--Recording and reproducing--Periodicals" .
+
+<http://example.org/11346685work12> a bf:Work;
+   bf:authorizedAccessPoint "Music technology";
+   bf:issn <urn:issn:0896-2480>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn87033459>;
+   bf:systemNumber <http://www.worldcat.org/oclc/16461726>;
+   bf:title "Music technology" .
+
+<http://example.org/11346685work13> a bf:Work;
+   bf:authorizedAccessPoint "Recording";
+   bf:issn <urn:issn:1078-8352>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/94642153>;
+   bf:systemNumber <http://www.worldcat.org/oclc/31020245>;
+   bf:title "Recording" .
+
+<http://example.org/11346685work14> a bf:Work;
+   bf:authorizedAccessPoint "Home & studio recording (Spanish ed.)";
+   bf:issn <urn:issn:1074-2050>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn94000149>;
+   bf:title "Home & studio recording (Spanish ed.)" .
+
+<http://example.org/11346685> a bf:Work,
+     bf:Text;
+   bf:absorbed <http://example.org/11346685work12>;
+   bf:authorizedAccessPoint "Home & studio recording.Home & studio recording",
+     "homestudiorecordingengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11346685classification10>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/TK7881.4>;
+   bf:continuedBy <http://example.org/11346685work13>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0896-7172"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0896-7172"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:otherEdition <http://example.org/11346685work14>;
+   bf:subject <http://example.org/11346685topic8>;
+   bf:workTitle <http://example.org/11346685title5> .

--- a/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/11338843.marcxml
+++ b/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/11338843.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01780cas a2200445 a 4500</leader>
   <controlfield tag="001">11338843</controlfield>
   <controlfield tag="005">20121214081036.0</controlfield>
@@ -134,4 +134,4 @@
     <subfield code="h">Microfilm 01104 no. 1544-1545 AP</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11338843</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/11737193.marcxml
+++ b/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/11737193.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01597cas a2200409 a 4500</leader>
   <controlfield tag="001">11737193</controlfield>
   <controlfield tag="005">20130424075220.0</controlfield>
@@ -123,4 +123,4 @@
     <subfield code="b">93000520</subfield>
     <subfield code="w">ACQUIRE</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11737193</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/12734030.marcxml
+++ b/spec/fixtures/loc/m2b-properties/otherPhysicalFormat/12734030.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01980cam a22003854a 4500</leader>
   <controlfield tag="001">12734030</controlfield>
   <controlfield tag="005">20050722075753.0</controlfield>
@@ -124,4 +124,4 @@
     <subfield code="u">http://ieeexplore.ieee.org/lpdocs/epic03/RecentCon.htm?punumber=7082</subfield>
     <subfield code="z">Restricted to IEEE Xplore subscribers</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12734030</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/partNumber/11707268.marcxml
+++ b/spec/fixtures/loc/m2b-properties/partNumber/11707268.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02449cgm a22003735a 4500</leader>
   <controlfield tag="001">11707268</controlfield>
   <controlfield tag="005">20130325073350.0</controlfield>
@@ -109,4 +109,4 @@
     <subfield code="h">VAD 6713 (viewing copy)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11707268</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/partNumber/16462440.marcxml
+++ b/spec/fixtures/loc/m2b-properties/partNumber/16462440.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02295cjm a2200337 a 4500</leader>
   <controlfield tag="001">16462440</controlfield>
   <controlfield tag="005">20101027075703.0</controlfield>
@@ -93,4 +93,4 @@
     <subfield code="a">Popular music</subfield>
     <subfield code="y">1961-1970.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16462440</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/partOf/16763577.marcxml
+++ b/spec/fixtures/loc/m2b-properties/partOf/16763577.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01964cam a2200421 a 4500</leader>
   <controlfield tag="001">16763577</controlfield>
   <controlfield tag="005">20110520142756.0</controlfield>
@@ -143,4 +143,4 @@
     <subfield code="6">520-00/$1</subfield>
     <subfield code="a">&#x300A;&#x6E05;&#x53F2;&#x7A3F;&#x300B;&#x662F;&#x7814;&#x7A76;&#x6211;&#x56FD;&#x6709;&#x5173;&#x6E05;&#x4EE3;&#x5386;&#x53F2;&#x7684;&#x4E00;&#x90E8;&#x91CD;&#x8981;&#x53F2;&#x6599;, &#x672C;&#x6587;&#x9009;&#x53D6;&#x5176;&#x4E2D;&#x7684;&#x300A;&#x4E50;&#x5FD7;&#x300B;&#x90E8;&#x5206;, &#x7740;&#x91CD;&#x4ECE;&#x8BBE;&#x7F6E;&#x4E0E;&#x7F16;&#x6B21;&#x3001;&#x7ED3;&#x6784;&#x4E0E;&#x5185;&#x5BB9;&#x4EE5;&#x53CA;&#x97F3;&#x4E50;&#x53F2;&#x5B66;&#x610F;&#x4E49;&#x4E09;&#x4E2A;&#x65B9;&#x9762;&#x8FDB;&#x884C;&#x4E86;&#x5206;&#x6790;, &#x8FDB;&#x800C;&#x5BF9;&#x300A;&#x6E05;&#x53F2;&#x7A3F;[MARC+A8]&#x4E50;&#x5FD7;&#x300B;&#x5728;&#x97F3;&#x4E50;&#x53F2;&#x7814;&#x7A76;&#x4E2D;&#x7684;&#x5730;&#x4F4D;&#x548C;&#x4EF7;&#x503C;&#x505A;&#x51FA;&#x4E86;&#x8BC4;&#x4EF7;.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16763577</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/partOf/16763577.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/partOf/16763577.rdfxml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/16763577">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Chen, Wannai. "Qing shi gao, yue zhi" yan jiu / Chen Wannai zhu."Qing shi gao, yue zhi" yan jiu《清史稿・乐志》研究</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/16763577title5"/>
+      <bf:creator rdf:resource="http://example.org/16763577person6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/chi"/>
+      <bf:subject rdf:resource="http://example.org/16763577topic8"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/a-cc"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/ML336"/>
+      <bf:hasPart rdf:resource="http://example.org/16763577work11"/>
+      <bf:series rdf:resource="http://example.org/16763577work12"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">chenwannaiqingshigaoyuezhiyanjiuchiworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/16763577work11">
+      <bf:title>Qing shi gao.</bf:title>
+      <bf:authorizedAccessPoint>Qing shi gao.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">清史稿. Selections. 2010.</bf:authorizedAccessPoint>
+      <bf:formDesignation>Selections.</bf:formDesignation>
+      <bf:originDate>2010.</bf:originDate>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/16763577work12">
+      <bf:title>Guo jia Qing shi bian zuan wei yuan hui yan jiu cong kan</bf:title>
+      <bf:authorizedAccessPoint>Guo jia Qing shi bian zuan wei yuan hui yan jiu cong kan</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">国家清史编纂委员会研究丛刊</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/16763577instance15">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/16763577title18"/>
+      <bf:titleVariation rdf:resource="http://example.org/16763577title19"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/7010085900"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9787010085906"/>
+      <bf:responsibilityStatement xml:lang="zh-hani">陈万鼐著.</bf:responsibilityStatement>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Ren min chu ban she</bf:label>
+                  <bf:label xml:lang="zh-hani">人民出版社</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Beijing </bf:label>
+                  <bf:label xml:lang="zh-hani">北京 :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>2010</bf:providerDate>
+            <bf:providerDate xml:lang="zh-hani">2010.</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:edition xml:lang="zh-hani">第 1 版.</bf:edition>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>4, 14, 12, 489 p. :</bf:extent>
+      <bf:dimensions>21 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>"Qing shi gao, yue zhi" yan jiu</bf:titleStatement>
+      <bf:edition>Di 1 ban.</bf:edition>
+      <bf:providerStatement>Beijing : Ren min chu ban she, 2010.</bf:providerStatement>
+      <bf:supplementaryContentNote>Includes bibliographical references.</bf:supplementaryContentNote>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2010426798</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/611873265"/>
+      <bf:instanceOf rdf:resource="http://example.org/16763577"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/16763577annotation14">
+      <bf:derivedFrom rdf:resource="http://example.org/16763577.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/cnpit"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/hua"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/bcbtc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2011-05-20T14:27</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/16763577"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/16763577helditem36">
+      <bf:label>ML336 .C475 2010</bf:label>
+      <bf:shelfMarkLcc>ML336 .C475 2010</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/16763577instance15"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/16763577title5">
+      <bf:label>"Qing shi gao, yue zhi" yan jiu / Chen Wannai zhu.</bf:label>
+      <bf:titleValue>"Qing shi gao, yue zhi" yan jiu</bf:titleValue>
+      <bf:titleValue xml:lang="zh-hani">《清史稿・乐志》研究</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/16763577person6">
+      <bf:label>Chen, Wannai.</bf:label>
+      <bf:authorizedAccessPoint>Chen, Wannai.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="zh-hani">陈万鼐.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Chen, Wannai.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Topic rdf:about="http://example.org/16763577topic8">
+      <bf:authorizedAccessPoint>Music--China--History and criticism</bf:authorizedAccessPoint>
+      <bf:label>Music--China--History and criticism</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Music--China--History and criticism</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Music</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Music</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>China</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>China</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>History and criticism</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>History and criticism.</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/16763577title18">
+      <bf:label>"Qing shi gao, yue zhi" yan jiu / Chen Wannai zhu.</bf:label>
+      <bf:titleValue>"Qing shi gao, yue zhi" yan jiu</bf:titleValue>
+      <bf:titleValue xml:lang="zh-hani">《清史稿・乐志》研究</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/16763577title19">
+      <bf:titleType>Colophon title also in pinyin:</bf:titleType>
+      <bf:label>Colophon title also in pinyin: Qingshigao yuezhi yanjiu</bf:label>
+      <bf:titleValue>Qingshigao yuezhi yanjiu</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/partOf/16763577.ttl
+++ b/spec/fixtures/loc/m2b-properties/partOf/16763577.ttl
@@ -1,0 +1,146 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/16763577annotation14> a bf:Annotation;
+   bf:annotates <http://example.org/16763577>;
+   bf:changeDate "2011-05-20T14:27";
+   bf:derivedFrom <http://example.org/16763577.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/hua>,
+     <http://id.loc.gov/vocabulary/organizations/bcbtc>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/cnpit>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/16763577helditem36> a bf:HeldItem;
+   bf:holdingFor <http://example.org/16763577instance15>;
+   bf:label "ML336 .C475 2010";
+   bf:shelfMarkLcc "ML336 .C475 2010" .
+
+<http://example.org/16763577instance15> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "21 cm.";
+   bf:edition "第 1 版."@zh-hani,
+     "Di 1 ban.";
+   bf:extent "4, 14, 12, 489 p. :";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/16763577>;
+   bf:instanceTitle <http://example.org/16763577title18>;
+   bf:isbn10 <http://isbn.example.org/7010085900>;
+   bf:isbn13 <http://isbn.example.org/9787010085906>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2010426798"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:providerStatement "Beijing : Ren min chu ban she, 2010.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "2010",
+       "2010."@zh-hani;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Ren min chu ban she",
+         "人民出版社"@zh-hani
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Beijing ",
+         "北京 :"@zh-hani
+     ]
+   ];
+   bf:responsibilityStatement "陈万鼐著."@zh-hani;
+   bf:supplementaryContentNote "Includes bibliographical references.";
+   bf:systemNumber <http://www.worldcat.org/oclc/611873265>;
+   bf:titleStatement "\"Qing shi gao, yue zhi\" yan jiu";
+   bf:titleVariation <http://example.org/16763577title19> .
+
+<http://example.org/16763577person6> a bf:Person;
+   bf:authorizedAccessPoint "Chen, Wannai.",
+     "陈万鼐."@zh-hani;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Chen, Wannai."
+   ];
+   bf:label "Chen, Wannai." .
+
+<http://example.org/16763577title18> a bf:Title;
+   bf:label "\"Qing shi gao, yue zhi\" yan jiu / Chen Wannai zhu.";
+   bf:titleValue "\"Qing shi gao, yue zhi\" yan jiu",
+     "《清史稿・乐志》研究"@zh-hani .
+
+<http://example.org/16763577title19> a bf:Title;
+   bf:label "Colophon title also in pinyin: Qingshigao yuezhi yanjiu";
+   bf:titleType "Colophon title also in pinyin:";
+   bf:titleValue "Qingshigao yuezhi yanjiu" .
+
+<http://example.org/16763577title5> a bf:Title;
+   bf:label "\"Qing shi gao, yue zhi\" yan jiu / Chen Wannai zhu.";
+   bf:titleValue "\"Qing shi gao, yue zhi\" yan jiu",
+     "《清史稿・乐志》研究"@zh-hani .
+
+<http://example.org/16763577topic8> a bf:Topic;
+   bf:authorizedAccessPoint "Music--China--History and criticism";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Music--China--History and criticism";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Music";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Music"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "China";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "China"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "History and criticism";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "History and criticism."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Music--China--History and criticism" .
+
+<http://example.org/16763577work11> a bf:Work;
+   bf:authorizedAccessPoint "Qing shi gao.",
+     "清史稿. Selections. 2010."@zh-hani;
+   bf:formDesignation "Selections.";
+   bf:originDate "2010.";
+   bf:title "Qing shi gao." .
+
+<http://example.org/16763577work12> a bf:Work;
+   bf:authorizedAccessPoint "Guo jia Qing shi bian zuan wei yuan hui yan jiu cong kan",
+     "国家清史编纂委员会研究丛刊"@zh-hani;
+   bf:title "Guo jia Qing shi bian zuan wei yuan hui yan jiu cong kan" .
+
+<http://example.org/16763577> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Chen, Wannai. \"Qing shi gao, yue zhi\" yan jiu / Chen Wannai zhu.\"Qing shi gao, yue zhi\" yan jiu《清史稿・乐志》研究",
+     "chenwannaiqingshigaoyuezhiyanjiuchiworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/ML336>;
+   bf:creator <http://example.org/16763577person6>;
+   bf:hasPart <http://example.org/16763577work11>;
+   bf:language <http://id.loc.gov/vocabulary/languages/chi>;
+   bf:series <http://example.org/16763577work12>;
+   bf:subject <http://example.org/16763577topic8>,
+     <http://id.loc.gov/vocabulary/geographicAreas/a-cc>;
+   bf:workTitle <http://example.org/16763577title5> .

--- a/spec/fixtures/loc/m2b-properties/partTitle/13673868.marcxml
+++ b/spec/fixtures/loc/m2b-properties/partTitle/13673868.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01324cam a22003254a 4500</leader>
   <controlfield tag="001">13673868</controlfield>
   <controlfield tag="005">20070825123245.0</controlfield>
@@ -107,4 +107,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13673868</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/performerNote/12076972.marcxml
+++ b/spec/fixtures/loc/m2b-properties/performerNote/12076972.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01747cjm a22003731a 4500</leader>
   <controlfield tag="001">12076972</controlfield>
   <controlfield tag="005">20000624075139.0</controlfield>
@@ -104,4 +104,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">Claimed Recordings</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12076972</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/postalRegistration/11346685.marcxml
+++ b/spec/fixtures/loc/m2b-properties/postalRegistration/11346685.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01830cas a2200481 a 4500</leader>
   <controlfield tag="001">11346685</controlfield>
   <controlfield tag="005">20130303163042.0</controlfield>
@@ -163,4 +163,4 @@
     <subfield code="b">MUS</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11346685</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/precededBy/16859464.marcxml
+++ b/spec/fixtures/loc/m2b-properties/precededBy/16859464.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01262cas a2200325 a 4500</leader>
   <controlfield tag="001">16859464</controlfield>
   <controlfield tag="005">20110707070828.0</controlfield>
@@ -96,4 +96,4 @@
     <subfield code="i">ff05 2011-07-01</subfield>
     <subfield code="g">ff05 2011-07-06 to LL</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16859464</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/precededBy/16859464.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/precededBy/16859464.rdfxml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/16859464">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Maine. Legislature. Legislative Youth Advisory Council. ...Biennial report to the Maine Legislature / Legislative Youth Advisory Council...Biennial report to the Maine Legislature</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/16859464title5"/>
+      <bf:creator rdf:resource="http://example.org/16859464jurisdiction6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/16859464organization8"/>
+      <bf:subject rdf:resource="http://example.org/16859464topic9"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us-me"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/KFM91.M5"/>
+      <bf:continues rdf:resource="http://example.org/16859464work12"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">mainelegislaturelegislativeyouthadvisorycouncilbiennialreporttothemainelegislatureengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/16859464work12">
+      <bf:title>Annual report of Maine Legislative Youth Advisory Council</bf:title>
+      <bf:authorizedAccessPoint>Maine. Legislature. Legislative Youth Advisory Council. Annual report of Maine Legislative Youth Advisory Council</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2004201803"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/51849067"/>
+      <bf:contributor rdf:resource="http://example.org/16859464agent18"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/16859464instance15">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/16859464title18"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Office of Policy and Legal Analysis</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Augusta, Me. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>2007-</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>...Biennial report to the Maine Legislature</bf:titleStatement>
+      <bf:providerStatement>Augusta, Me. : Office of Policy and Legal Analysis, 2007-</bf:providerStatement>
+      <bf:frequencyNote>Biennial</bf:frequencyNote>
+      <bf:note>Description based on: 2007; title from cover</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2011215139</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/184987547"/>
+      <bf:serialFirstIssue>2007</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/16859464"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/16859464annotation14">
+      <bf:derivedFrom rdf:resource="http://example.org/16859464.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/melr"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2011-07-07T07:08</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/16859464"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/16859464helditem32">
+      <bf:label>KFM91.M5 A165</bf:label>
+      <bf:shelfMarkLcc>KFM91.M5 A165</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/16859464instance15"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/16859464title5">
+      <bf:label>...Biennial report to the Maine Legislature / Legislative Youth Advisory Council</bf:label>
+      <bf:titleValue>...Biennial report to the Maine Legislature</bf:titleValue>
+   </bf:Title>
+   <bf:Jurisdiction rdf:about="http://example.org/16859464jurisdiction6">
+      <bf:label>Maine. Legislature. Legislative Youth Advisory Council.</bf:label>
+      <bf:authorizedAccessPoint>Maine. Legislature. Legislative Youth Advisory Council.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Maine. Legislature. Legislative Youth Advisory Council.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Organization rdf:about="http://example.org/16859464organization8">
+      <bf:authorizedAccessPoint>Maine. Legislature. Legislative Youth Advisory Council.</bf:authorizedAccessPoint>
+      <bf:label>Maine. Legislature. Legislative Youth Advisory Council.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+            <madsrdf:authoritativeLabel>Maine. Legislature. Legislative Youth Advisory Council.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/16859464topic9">
+      <bf:authorizedAccessPoint>Youth--Maine</bf:authorizedAccessPoint>
+      <bf:label>Youth--Maine</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Youth--Maine</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Youth</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Youth</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Maine</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Maine.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Agent rdf:about="http://example.org/16859464agent18">
+      <bf:label>Maine. Legislature. Legislative Youth Advisory Council.</bf:label>
+      <bf:authorizedAccessPoint>Maine. Legislature. Legislative Youth Advisory Council.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Maine. Legislature. Legislative Youth Advisory Council.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/16859464title18">
+      <bf:label>...Biennial report to the Maine Legislature / Legislative Youth Advisory Council</bf:label>
+      <bf:titleValue>...Biennial report to the Maine Legislature</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/precededBy/16859464.ttl
+++ b/spec/fixtures/loc/m2b-properties/precededBy/16859464.ttl
@@ -1,0 +1,133 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/16859464annotation14> a bf:Annotation;
+   bf:annotates <http://example.org/16859464>;
+   bf:changeDate "2011-07-07T07:08";
+   bf:derivedFrom <http://example.org/16859464.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/melr>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/16859464helditem32> a bf:HeldItem;
+   bf:holdingFor <http://example.org/16859464instance15>;
+   bf:label "KFM91.M5 A165";
+   bf:shelfMarkLcc "KFM91.M5 A165" .
+
+<http://example.org/16859464agent18> a bf:Agent;
+   bf:authorizedAccessPoint "Maine. Legislature. Legislative Youth Advisory Council.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Maine. Legislature. Legislative Youth Advisory Council."
+   ];
+   bf:label "Maine. Legislature. Legislative Youth Advisory Council." .
+
+<http://example.org/16859464instance15> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "28 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Biennial";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/16859464>;
+   bf:instanceTitle <http://example.org/16859464title18>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2011215139"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Description based on: 2007; title from cover";
+   bf:providerStatement "Augusta, Me. : Office of Policy and Legal Analysis, 2007-";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "2007-";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Office of Policy and Legal Analysis"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Augusta, Me. "
+     ]
+   ];
+   bf:serialFirstIssue "2007";
+   bf:systemNumber <http://www.worldcat.org/oclc/184987547>;
+   bf:titleStatement "...Biennial report to the Maine Legislature" .
+
+<http://example.org/16859464jurisdiction6> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Maine. Legislature. Legislative Youth Advisory Council.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Maine. Legislature. Legislative Youth Advisory Council."
+   ];
+   bf:label "Maine. Legislature. Legislative Youth Advisory Council." .
+
+<http://example.org/16859464organization8> a bf:Organization;
+   bf:authorizedAccessPoint "Maine. Legislature. Legislative Youth Advisory Council.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:CorporateName;
+     mads:authoritativeLabel "Maine. Legislature. Legislative Youth Advisory Council.";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Maine. Legislature. Legislative Youth Advisory Council." .
+
+<http://example.org/16859464title18> a bf:Title;
+   bf:label "...Biennial report to the Maine Legislature / Legislative Youth Advisory Council";
+   bf:titleValue "...Biennial report to the Maine Legislature" .
+
+<http://example.org/16859464title5> a bf:Title;
+   bf:label "...Biennial report to the Maine Legislature / Legislative Youth Advisory Council";
+   bf:titleValue "...Biennial report to the Maine Legislature" .
+
+<http://example.org/16859464topic9> a bf:Topic;
+   bf:authorizedAccessPoint "Youth--Maine";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Youth--Maine";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Youth";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Youth"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Maine";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Maine."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Youth--Maine" .
+
+<http://example.org/16859464work12> a bf:Work;
+   bf:authorizedAccessPoint "Maine. Legislature. Legislative Youth Advisory Council. Annual report of Maine Legislative Youth Advisory Council";
+   bf:contributor <http://example.org/16859464agent18>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2004201803>;
+   bf:systemNumber <http://www.worldcat.org/oclc/51849067>;
+   bf:title "Annual report of Maine Legislative Youth Advisory Council" .
+
+<http://example.org/16859464> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Maine. Legislature. Legislative Youth Advisory Council. ...Biennial report to the Maine Legislature / Legislative Youth Advisory Council...Biennial report to the Maine Legislature",
+     "mainelegislaturelegislativeyouthadvisorycouncilbiennialreporttothemainelegislatureengworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/KFM91.M5>;
+   bf:continues <http://example.org/16859464work12>;
+   bf:creator <http://example.org/16859464jurisdiction6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/16859464organization8>,
+     <http://example.org/16859464topic9>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us-me>;
+   bf:workTitle <http://example.org/16859464title5> .

--- a/spec/fixtures/loc/m2b-properties/preferredCitation/17106072.marcxml
+++ b/spec/fixtures/loc/m2b-properties/preferredCitation/17106072.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02027nkd a22004213a 4500</leader>
   <controlfield tag="001">17106072</controlfield>
   <controlfield tag="005">20120105113928.0</controlfield>
@@ -130,4 +130,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="m">(ONLINE)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17106072</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/production/8661169.marcxml
+++ b/spec/fixtures/loc/m2b-properties/production/8661169.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00729cam a2200217u  4500</leader>
   <controlfield tag="001">8661169</controlfield>
   <controlfield tag="005">20040116132346.0</controlfield>
@@ -64,4 +64,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=8661169</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/provider/11267155.marcxml
+++ b/spec/fixtures/loc/m2b-properties/provider/11267155.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01239cas a22003377a 4500</leader>
   <controlfield tag="001">11267155</controlfield>
   <controlfield tag="005">20130302155721.0</controlfield>
@@ -99,4 +99,4 @@
     <subfield code="h">Newspaper 7002</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11267155</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/providerDate/11292563.marcxml
+++ b/spec/fixtures/loc/m2b-properties/providerDate/11292563.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01663cas a2200397 a 4500</leader>
   <controlfield tag="001">11292563</controlfield>
   <controlfield tag="005">20121213084552.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="i">.N2842</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11292563</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/providerName/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/providerName/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/providerPlace/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/providerPlace/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/providerRole/3235758.marcxml
+++ b/spec/fixtures/loc/m2b-properties/providerRole/3235758.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00638nam a2200205 i 4500</leader>
   <controlfield tag="001">3235758</controlfield>
   <controlfield tag="005">19790612000000.0</controlfield>
@@ -62,4 +62,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3235758</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/providerStatement/16845697.marcxml
+++ b/spec/fixtures/loc/m2b-properties/providerStatement/16845697.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00530cas a22001814a 4500</leader>
   <controlfield tag="001">16845697</controlfield>
   <controlfield tag="005">20110816110341.0</controlfield>
@@ -45,4 +45,4 @@
   <datafield tag="984" ind1=" " ind2=" ">
     <subfield code="b">Record input for RHIP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16845697</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/publication/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/publication/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/publisherNumber/11350728.marcxml
+++ b/spec/fixtures/loc/m2b-properties/publisherNumber/11350728.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01992cas a2200505 a 4500</leader>
   <controlfield tag="001">11350728</controlfield>
   <controlfield tag="005">20130225113900.0</controlfield>
@@ -178,4 +178,4 @@
   <datafield tag="984" ind1=" " ind2=" ">
     <subfield code="a">srvf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11350728</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/relatedInstance/3556119.marcxml
+++ b/spec/fixtures/loc/m2b-properties/relatedInstance/3556119.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01568nam a2200397 a 4500</leader>
   <controlfield tag="001">3556119</controlfield>
   <controlfield tag="005">19980212092839.1</controlfield>
@@ -125,4 +125,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3556119</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/relatedWork/11515605.marcxml
+++ b/spec/fixtures/loc/m2b-properties/relatedWork/11515605.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04266cgm a2200649 i 4500</leader>
   <controlfield tag="001">11515605</controlfield>
   <controlfield tag="005">20110725102849.0</controlfield>
@@ -197,4 +197,4 @@
     <subfield code="h">FBC 1867 (ref print)</subfield>
     <subfield code="w">MUMS VM File</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11515605</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/relatedWork/11515605.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/relatedWork/11515605.rdfxml
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11515605">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/MovingImage"/>
+      <bf:authorizedAccessPoint>Ames, Alfred, 1866-1950 From stump to ship (Motion picture 1986)</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>From stump to ship (Motion picture 1986)</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/11515605title6"/>
+      <relators:fmk rdf:resource="http://example.org/11515605person7"/>
+      <bf:contributor rdf:resource="http://example.org/11515605person8"/>
+      <relators:fmp rdf:resource="http://example.org/11515605person9"/>
+      <relators:fmp rdf:resource="http://example.org/11515605person10"/>
+      <relators:fmp rdf:resource="http://example.org/11515605person11"/>
+      <relators:nrt rdf:resource="http://example.org/11515605person12"/>
+      <relators:spn rdf:resource="http://example.org/11515605organization13"/>
+      <relators:fds rdf:resource="http://example.org/11515605organization14"/>
+      <bf:contributor rdf:resource="http://example.org/11515605organization15"/>
+      <bf:event rdf:resource="http://example.org/11515605event16"/>
+      <bf:note>Filmed in 1930 in Washington County, Maine.</bf:note>
+      <bf:awardNote>This film was selected for the National Film Registry.</bf:awardNote>
+      <bf:contentCategory rdf:resource="http://id.loc.gov/vocabulary/contentTypes/tdi"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic22"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic23"/>
+      <bf:subject rdf:resource="http://example.org/11515605organization24"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic25"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic26"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic27"/>
+      <bf:subject rdf:resource="http://example.org/11515605topic28"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us-me"/>
+      <bf:relatedResource rdf:resource="http://example.org/11515605work30"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">amesalfred18661950kanehoward18871946weissdavids1954sheldonkarannevisonhenrysampletim1951universityofmaineatorononortheasthistoricfilmorganizationcopyrightcollectionlibraryofcongressfromstumptoshipmotionpicture1986engworkmovingimage</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11515605work30">
+      <bf:title>From stump to ship (Motion picture 1930)</bf:title>
+      <bf:authorizedAccessPoint>From stump to ship (Motion picture 1930)</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11515605instance33">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11515605title36"/>
+      <bf:titleVariation rdf:resource="http://example.org/11515605title37"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Northeast Historic Film</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Bucksport, Maine </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>[1986] ©1985</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:soundContent>Sound on medium</bf:soundContent>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>1 film reel (26 min., 24 sec., 990 ft.) : viewing print.</bf:extent>
+      <bf:dimensions>16 mm</bf:dimensions>
+      <bf:illustrationNote>sound, black and white, positive ;</bf:illustrationNote>
+      <bf:titleStatement>From stump to ship</bf:titleStatement>
+      <bf:edition>Reconstruction with added prologue and sound</bf:edition>
+      <bf:editionResponsibility>A Project of The University of Maine at Orono and Northeast Archives of Folklore and Oral History ; executive producer and project director, Henry Nevison.</bf:editionResponsibility>
+      <bf:providerStatement>Bucksport, Maine : Northeast Historic Film, 1986 ©1985.</bf:providerStatement>
+      <bf:creditsNote>Credits: Camera, Alfred Ames, Dr. Howard Kane ; traditional music, Sandy Ives, Albert Pelletier, Bill Schubeck ; script editor, Karan Sheldon ; film editors, Henry Nevison, David Weiss.</bf:creditsNote>
+      <bf:performerNote>Narrator: Tim Sample.</bf:performerNote>
+      <bf:note>Generation: composite positive.</bf:note>
+      <bf:note>"The long log drive: a spring journey down icy streams and rivers moving logs from the forest to the mill for sawing into boards, laths, and clapboards. For more than 150 years, logging techniques remained the same. Men cut trees by hand and loaded them on horse-drawn sleds to be hauled over snow to the river. Skilled river drivers maneuvered the logs downstream, risking their limbs and lives every day. This film survives as a record of the long log business. Highly detailed scenes, filmed year-round, are uniquely enhanced by the original script, written to be read with the silent footage in the 1930s. The soundtrack is brought to life by Tim Sample, narrator and renowned Maine humorist, in the role of the filmmaker, Alfred Ames"--National Archives and Record Service WWW site.</bf:note>
+      <bf:note>Made with the support of The Maine Humanities Council and the National Endowment for the Humanities and Champion International Corporation.</bf:note>
+      <bf:note>This film was selected for the National Film Registry.</bf:note>
+      <bf:note>According to the Northeast Historic Film WWW site, the original script was written by Alfred Ames and his nephew, Rufus Fuller.</bf:note>
+      <bf:note>Sources used: Wikipedia WWW site, viewed Oct. 7, 2010; Northeast Historic Film WWW site (From Stump to Ship : Forgotten Film to the Formation of a Film Archives article, by Janna Jones), viewed Oct. 7, 2010; National Archives and Record Service WWW site, viewed Sep. 28, 2010.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>88708240</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:legalDeposit>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/legalDeposit"/>
+            <bf:identifierValue>PA358-831</bf:identifierValue>
+            <bf:identifierAssigner>U.S. Copyright Office</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:legalDeposit>
+      <bf:mediaCategory rdf:resource="http://id.loc.gov/vocabulary/mediaTypes/g"/>
+      <bf:carrierCategory rdf:resource="http://id.loc.gov/vocabulary/carriers/mr"/>
+      <bf:instanceOf rdf:resource="http://example.org/11515605"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11515605annotation32">
+      <bf:derivedFrom rdf:resource="http://example.org/11515605.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/rda"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/isbd"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2011-07-25T10:28</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11515605"/>
+   </bf:Annotation>
+   <bf:Summary rdf:about="http://example.org/11515605summary21">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Summary"/>
+      <bf:label>Summary</bf:label>
+      <bf:annotationAssertedBy rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:annotationBody>"The long log drive: a spring journey down icy streams and rivers moving logs from the forest to the mill for sawing into boards, laths, and clapboards. For more than 150 years, logging techniques remained the same. Men cut trees by hand and loaded them on horse-drawn sleds to be hauled over snow to the river. Skilled river drivers maneuvered the logs downstream, risking their limbs and lives every day. This film survives as a record of the long log business. Highly detailed scenes, filmed year-round, are uniquely enhanced by the original script, written to be read with the silent footage in the 1930s. The soundtrack is brought to life by Tim Sample, narrator and renowned Maine humorist, in the role of the filmmaker, Alfred Ames"--National Archives and Record Service WWW site.</bf:annotationBody>
+      <bf:summaryOf rdf:resource="http://example.org/11515605"/>
+   </bf:Summary>
+   <bf:Title rdf:about="http://example.org/11515605title6">
+      <bf:titleValue>From stump to ship (Motion picture : 1986)</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/11515605person7">
+      <bf:label>Ames, Alfred, 1866-1950</bf:label>
+      <bf:authorizedAccessPoint>Ames, Alfred, 1866-1950</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Ames, Alfred, 1866-1950</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11515605person8">
+      <bf:label>Kane, Howard, 1887-1946</bf:label>
+      <bf:authorizedAccessPoint>Kane, Howard, 1887-1946</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Kane, Howard, 1887-1946</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11515605person9">
+      <bf:label>Weiss, David S., 1954-</bf:label>
+      <bf:authorizedAccessPoint>Weiss, David S., 1954-</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Weiss, David S., 1954-</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11515605person10">
+      <bf:label>Sheldon, Karan</bf:label>
+      <bf:authorizedAccessPoint>Sheldon, Karan</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Sheldon, Karan</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11515605person11">
+      <bf:label>Nevison, Henry</bf:label>
+      <bf:authorizedAccessPoint>Nevison, Henry</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Nevison, Henry</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Person rdf:about="http://example.org/11515605person12">
+      <bf:label>Sample, Tim, 1951-</bf:label>
+      <bf:authorizedAccessPoint>Sample, Tim, 1951-</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Sample, Tim, 1951-</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Organization rdf:about="http://example.org/11515605organization13">
+      <bf:label>University of Maine at Orono</bf:label>
+      <bf:authorizedAccessPoint>University of Maine at Orono</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>University of Maine at Orono</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Organization rdf:about="http://example.org/11515605organization14">
+      <bf:label>Northeast Historic Film (Organization)</bf:label>
+      <bf:authorizedAccessPoint>Northeast Historic Film (Organization)</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Northeast Historic Film (Organization)</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Organization rdf:about="http://example.org/11515605organization15">
+      <bf:label>Copyright Collection (Library of Congress)</bf:label>
+      <bf:authorizedAccessPoint>Copyright Collection (Library of Congress)</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Copyright Collection (Library of Congress)</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Event rdf:about="http://example.org/11515605event16">
+      <bf:eventDate rdf:datatype="xsd:dateTime">1930----</bf:eventDate>
+      <bf:eventPlace rdf:resource="http://id.loc.gov/authorities/classification/G3733.W4"/>
+   </bf:Event>
+   <bf:Topic rdf:about="http://example.org/11515605topic22">
+      <bf:authorizedAccessPoint>Logging--Maine</bf:authorizedAccessPoint>
+      <bf:label>Logging--Maine</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Logging--Maine</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Logging</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Logging</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Maine</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Maine.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11515605topic23">
+      <bf:authorizedAccessPoint>Lumber trade--Maine</bf:authorizedAccessPoint>
+      <bf:label>Lumber trade--Maine</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Lumber trade--Maine</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Lumber trade</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Lumber trade</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Maine</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Maine.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Organization rdf:about="http://example.org/11515605organization24">
+      <bf:authorizedAccessPoint>Machias Lumber Company (Machias, Me.)</bf:authorizedAccessPoint>
+      <bf:label>Machias Lumber Company (Machias, Me.)</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#CorporateName"/>
+            <madsrdf:authoritativeLabel>Machias Lumber Company (Machias, Me.)</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11515605topic25">
+      <bf:authorizedAccessPoint>Industrial films</bf:authorizedAccessPoint>
+      <bf:label>Industrial films</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#GenreForm"/>
+            <madsrdf:authoritativeLabel>Industrial films</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lcgft"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lcgft</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11515605topic26">
+      <bf:authorizedAccessPoint>Amateur films</bf:authorizedAccessPoint>
+      <bf:label>Amateur films</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#GenreForm"/>
+            <madsrdf:authoritativeLabel>Amateur films</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lcgft"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lcgft</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11515605topic27">
+      <bf:authorizedAccessPoint>Short films</bf:authorizedAccessPoint>
+      <bf:label>Short films</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#GenreForm"/>
+            <madsrdf:authoritativeLabel>Short films</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lcgft"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lcgft</bf:authoritySource>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11515605topic28">
+      <bf:authorizedAccessPoint>Nonfiction films</bf:authorizedAccessPoint>
+      <bf:label>Nonfiction films</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#GenreForm"/>
+            <madsrdf:authoritativeLabel>Nonfiction films</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/lcgft"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+      <bf:authoritySource>http://id.loc.gov/vocabulary/subjectSchemes/lcgft</bf:authoritySource>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11515605title36">
+      <bf:label>From stump to ship / a film by Alfred Ames ; producers, David Weiss and Karan Sheldon.</bf:label>
+      <bf:titleValue>From stump to ship</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11515605title37">
+      <bf:titleType>Variant title from the Internet movie database:</bf:titleType>
+      <bf:label>Variant title from the Internet movie database: From Stump to Ship: A 1930 Logging Film</bf:label>
+      <bf:titleValue>From Stump to Ship: A 1930 Logging Film</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/relatedWork/11515605.ttl
+++ b/spec/fixtures/loc/m2b-properties/relatedWork/11515605.ttl
@@ -1,0 +1,300 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix marcrelators: <http://id.loc.gov/vocabulary/relators/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11515605annotation32> a bf:Annotation;
+   bf:annotates <http://example.org/11515605>;
+   bf:changeDate "2011-07-25T10:28";
+   bf:derivedFrom <http://example.org/11515605.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/rda>,
+     <http://id.loc.gov/vocabulary/descriptionConventions/isbd>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11515605instance33> a bf:Instance,
+     bf:Monograph;
+   bf:carrierCategory <http://id.loc.gov/vocabulary/carriers/mr>;
+   bf:creditsNote "Credits: Camera, Alfred Ames, Dr. Howard Kane ; traditional music, Sandy Ives, Albert Pelletier, Bill Schubeck ; script editor, Karan Sheldon ; film editors, Henry Nevison, David Weiss.";
+   bf:dimensions "16 mm";
+   bf:edition "Reconstruction with added prologue and sound";
+   bf:editionResponsibility "A Project of The University of Maine at Orono and Northeast Archives of Folklore and Oral History ; executive producer and project director, Henry Nevison.";
+   bf:extent "1 film reel (26 min., 24 sec., 990 ft.) : viewing print.";
+   bf:illustrationNote "sound, black and white, positive ;";
+   bf:instanceOf <http://example.org/11515605>;
+   bf:instanceTitle <http://example.org/11515605title36>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "88708240"
+   ];
+   bf:legalDeposit [
+     a bf:Identifier;
+     bf:identifierAssigner "U.S. Copyright Office";
+     bf:identifierScheme loc_ids:legalDeposit;
+     bf:identifierValue "PA358-831"
+   ];
+   bf:mediaCategory <http://id.loc.gov/vocabulary/mediaTypes/g>;
+   bf:modeOfIssuance "single unit";
+   bf:note "Generation: composite positive.",
+     "\"The long log drive: a spring journey down icy streams and rivers moving logs from the forest to the mill for sawing into boards, laths, and clapboards. For more than 150 years, logging techniques remained the same. Men cut trees by hand and loaded them on horse-drawn sleds to be hauled over snow to the river. Skilled river drivers maneuvered the logs downstream, risking their limbs and lives every day. This film survives as a record of the long log business. Highly detailed scenes, filmed year-round, are uniquely enhanced by the original script, written to be read with the silent footage in the 1930s. The soundtrack is brought to life by Tim Sample, narrator and renowned Maine humorist, in the role of the filmmaker, Alfred Ames\"--National Archives and Record Service WWW site.",
+     "Made with the support of The Maine Humanities Council and the National Endowment for the Humanities and Champion International Corporation.",
+     "This film was selected for the National Film Registry.",
+     "According to the Northeast Historic Film WWW site, the original script was written by Alfred Ames and his nephew, Rufus Fuller.",
+     "Sources used: Wikipedia WWW site, viewed Oct. 7, 2010; Northeast Historic Film WWW site (From Stump to Ship : Forgotten Film to the Formation of a Film Archives article, by Janna Jones), viewed Oct. 7, 2010; National Archives and Record Service WWW site, viewed Sep. 28, 2010.";
+   bf:performerNote "Narrator: Tim Sample.";
+   bf:providerStatement "Bucksport, Maine : Northeast Historic Film, 1986 ©1985.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "[1986] ©1985";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Northeast Historic Film"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Bucksport, Maine "
+     ]
+   ];
+   bf:soundContent "Sound on medium";
+   bf:titleStatement "From stump to ship";
+   bf:titleVariation <http://example.org/11515605title37> .
+
+<http://example.org/11515605summary21> a bf:Summary;
+   bf:annotationAssertedBy <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:annotationBody "\"The long log drive: a spring journey down icy streams and rivers moving logs from the forest to the mill for sawing into boards, laths, and clapboards. For more than 150 years, logging techniques remained the same. Men cut trees by hand and loaded them on horse-drawn sleds to be hauled over snow to the river. Skilled river drivers maneuvered the logs downstream, risking their limbs and lives every day. This film survives as a record of the long log business. Highly detailed scenes, filmed year-round, are uniquely enhanced by the original script, written to be read with the silent footage in the 1930s. The soundtrack is brought to life by Tim Sample, narrator and renowned Maine humorist, in the role of the filmmaker, Alfred Ames\"--National Archives and Record Service WWW site.";
+   bf:label "Summary";
+   bf:summaryOf <http://example.org/11515605> .
+
+<http://example.org/11515605event16> a bf:Event;
+   bf:eventDate "1930----"^^<xsd:dateTime>;
+   bf:eventPlace <http://id.loc.gov/authorities/classification/G3733.W4> .
+
+<http://example.org/11515605organization13> a bf:Organization;
+   bf:authorizedAccessPoint "University of Maine at Orono";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "University of Maine at Orono"
+   ];
+   bf:label "University of Maine at Orono" .
+
+<http://example.org/11515605organization14> a bf:Organization;
+   bf:authorizedAccessPoint "Northeast Historic Film (Organization)";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Northeast Historic Film (Organization)"
+   ];
+   bf:label "Northeast Historic Film (Organization)" .
+
+<http://example.org/11515605organization15> a bf:Organization;
+   bf:authorizedAccessPoint "Copyright Collection (Library of Congress)";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Copyright Collection (Library of Congress)"
+   ];
+   bf:label "Copyright Collection (Library of Congress)" .
+
+<http://example.org/11515605organization24> a bf:Organization;
+   bf:authorizedAccessPoint "Machias Lumber Company (Machias, Me.)";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:CorporateName;
+     mads:authoritativeLabel "Machias Lumber Company (Machias, Me.)";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Machias Lumber Company (Machias, Me.)" .
+
+<http://example.org/11515605person10> a bf:Person;
+   bf:authorizedAccessPoint "Sheldon, Karan";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Sheldon, Karan"
+   ];
+   bf:label "Sheldon, Karan" .
+
+<http://example.org/11515605person11> a bf:Person;
+   bf:authorizedAccessPoint "Nevison, Henry";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Nevison, Henry"
+   ];
+   bf:label "Nevison, Henry" .
+
+<http://example.org/11515605person12> a bf:Person;
+   bf:authorizedAccessPoint "Sample, Tim, 1951-";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Sample, Tim, 1951-"
+   ];
+   bf:label "Sample, Tim, 1951-" .
+
+<http://example.org/11515605person7> a bf:Person;
+   bf:authorizedAccessPoint "Ames, Alfred, 1866-1950";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Ames, Alfred, 1866-1950"
+   ];
+   bf:label "Ames, Alfred, 1866-1950" .
+
+<http://example.org/11515605person8> a bf:Person;
+   bf:authorizedAccessPoint "Kane, Howard, 1887-1946";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Kane, Howard, 1887-1946"
+   ];
+   bf:label "Kane, Howard, 1887-1946" .
+
+<http://example.org/11515605person9> a bf:Person;
+   bf:authorizedAccessPoint "Weiss, David S., 1954-";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Weiss, David S., 1954-"
+   ];
+   bf:label "Weiss, David S., 1954-" .
+
+<http://example.org/11515605title36> a bf:Title;
+   bf:label "From stump to ship / a film by Alfred Ames ; producers, David Weiss and Karan Sheldon.";
+   bf:titleValue "From stump to ship" .
+
+<http://example.org/11515605title37> a bf:Title;
+   bf:label "Variant title from the Internet movie database: From Stump to Ship: A 1930 Logging Film";
+   bf:titleType "Variant title from the Internet movie database:";
+   bf:titleValue "From Stump to Ship: A 1930 Logging Film" .
+
+<http://example.org/11515605title6> a bf:Title;
+   bf:titleValue "From stump to ship (Motion picture : 1986)" .
+
+<http://example.org/11515605topic22> a bf:Topic;
+   bf:authorizedAccessPoint "Logging--Maine";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Logging--Maine";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Logging";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Logging"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Maine";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Maine."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Logging--Maine" .
+
+<http://example.org/11515605topic23> a bf:Topic;
+   bf:authorizedAccessPoint "Lumber trade--Maine";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Lumber trade--Maine";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Lumber trade";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Lumber trade"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Maine";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Maine."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Lumber trade--Maine" .
+
+<http://example.org/11515605topic25> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lcgft";
+   bf:authorizedAccessPoint "Industrial films";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:GenreForm;
+     mads:authoritativeLabel "Industrial films";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lcgft>
+   ];
+   bf:label "Industrial films" .
+
+<http://example.org/11515605topic26> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lcgft";
+   bf:authorizedAccessPoint "Amateur films";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:GenreForm;
+     mads:authoritativeLabel "Amateur films";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lcgft>
+   ];
+   bf:label "Amateur films" .
+
+<http://example.org/11515605topic27> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lcgft";
+   bf:authorizedAccessPoint "Short films";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:GenreForm;
+     mads:authoritativeLabel "Short films";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lcgft>
+   ];
+   bf:label "Short films" .
+
+<http://example.org/11515605topic28> a bf:Topic;
+   bf:authoritySource "http://id.loc.gov/vocabulary/subjectSchemes/lcgft";
+   bf:authorizedAccessPoint "Nonfiction films";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:GenreForm;
+     mads:authoritativeLabel "Nonfiction films";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/lcgft>
+   ];
+   bf:label "Nonfiction films" .
+
+<http://example.org/11515605work30> a bf:Work;
+   bf:authorizedAccessPoint "From stump to ship (Motion picture 1930)";
+   bf:title "From stump to ship (Motion picture 1930)" .
+
+<http://example.org/11515605> a bf:Work,
+     bf:MovingImage;
+   bf:authorizedAccessPoint "Ames, Alfred, 1866-1950 From stump to ship (Motion picture 1986)",
+     "amesalfred18661950kanehoward18871946weissdavids1954sheldonkarannevisonhenrysampletim1951universityofmaineatorononortheasthistoricfilmorganizationcopyrightcollectionlibraryofcongressfromstumptoshipmotionpicture1986engworkmovingimage"@x-bf-hash;
+   bf:awardNote "This film was selected for the National Film Registry.";
+   bf:contentCategory <http://id.loc.gov/vocabulary/contentTypes/tdi>;
+   bf:contributor <http://example.org/11515605person8>,
+     <http://example.org/11515605organization15>;
+   bf:event <http://example.org/11515605event16>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:note "Filmed in 1930 in Washington County, Maine.";
+   bf:relatedResource <http://example.org/11515605work30>;
+   bf:subject <http://example.org/11515605topic22>,
+     <http://example.org/11515605topic23>,
+     <http://example.org/11515605organization24>,
+     <http://example.org/11515605topic25>,
+     <http://example.org/11515605topic26>,
+     <http://example.org/11515605topic27>,
+     <http://example.org/11515605topic28>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us-me>;
+   bf:workTitle <http://example.org/11515605title6>;
+   marcrelators:fds <http://example.org/11515605organization14>;
+   marcrelators:fmk <http://example.org/11515605person7>;
+   marcrelators:fmp <http://example.org/11515605person9>,
+     <http://example.org/11515605person10>,
+     <http://example.org/11515605person11>;
+   marcrelators:nrt <http://example.org/11515605person12>;
+   marcrelators:spn <http://example.org/11515605organization13>;
+   mads:authoritativeLabel "From stump to ship (Motion picture 1986)" .

--- a/spec/fixtures/loc/m2b-properties/reportNumber/13987899.marcxml
+++ b/spec/fixtures/loc/m2b-properties/reportNumber/13987899.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02004cam a22004214a 4500</leader>
   <controlfield tag="001">13987899</controlfield>
   <controlfield tag="005">20130530123819.0</controlfield>
@@ -122,4 +122,4 @@
   <datafield tag="856" ind1="4" ind2="1">
     <subfield code="u">http://purl.access.gpo.gov/GPO/LPS59843</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13987899</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/reproduction/723007.marcxml
+++ b/spec/fixtures/loc/m2b-properties/reproduction/723007.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01205nam a22003137a 4500</leader>
   <controlfield tag="001">723007</controlfield>
   <controlfield tag="005">19980205055336.8</controlfield>

--- a/spec/fixtures/loc/m2b-properties/resourcePart/12076972.marcxml
+++ b/spec/fixtures/loc/m2b-properties/resourcePart/12076972.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01747cjm a22003731a 4500</leader>
   <controlfield tag="001">12076972</controlfield>
   <controlfield tag="005">20000624075139.0</controlfield>
@@ -104,4 +104,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">Claimed Recordings</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12076972</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/reviewOf/4934508.marcxml
+++ b/spec/fixtures/loc/m2b-properties/reviewOf/4934508.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01867cam a2200325 a 4500</leader>
   <controlfield tag="001">4934508</controlfield>
   <controlfield tag="005">20050524180354.0</controlfield>
@@ -94,4 +94,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=4934508</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/serialFirstIssue/17125262.marcxml
+++ b/spec/fixtures/loc/m2b-properties/serialFirstIssue/17125262.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01944cas a2200433 a 4500</leader>
   <controlfield tag="001">17125262</controlfield>
   <controlfield tag="005">20120313155919.0</controlfield>
@@ -136,4 +136,4 @@
     <subfield code="a">fe00 2012-01-18</subfield>
     <subfield code="i">fe04 2012-01-18 (EurRR uncataloged serials) to BCCD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17125262</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/serialLastIssue/17125262.marcxml
+++ b/spec/fixtures/loc/m2b-properties/serialLastIssue/17125262.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01944cas a2200433 a 4500</leader>
   <controlfield tag="001">17125262</controlfield>
   <controlfield tag="005">20120313155919.0</controlfield>
@@ -136,4 +136,4 @@
     <subfield code="a">fe00 2012-01-18</subfield>
     <subfield code="i">fe04 2012-01-18 (EurRR uncataloged serials) to BCCD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17125262</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/series/13694403.marcxml
+++ b/spec/fixtures/loc/m2b-properties/series/13694403.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01454cam a22003854a 4500</leader>
   <controlfield tag="001">13694403</controlfield>
   <controlfield tag="005">20070824234633.0</controlfield>
@@ -130,4 +130,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="a">spacingreload</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13694403</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/series/13694403.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/series/13694403.rdfxml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/13694403">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Hoshi, Ryōichi, 1935- Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.Aizu rakujō :Boshin Sensō saidai no higeki 会津落城 戊辰戦争最大の悲劇</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/13694403title5"/>
+      <bf:creator rdf:resource="http://example.org/13694403person6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/jpn"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/a-ja"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/DS881.83"/>
+      <bf:classification rdf:resource="http://example.org/13694403classification10"/>
+      <bf:series rdf:resource="http://example.org/13694403work11"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">hoshiryōichi1935aizurakujōboshinsensōsaidainohigekijpnworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13694403work11">
+      <bf:title>Chūkō shinsho ; 1728</bf:title>
+      <bf:authorizedAccessPoint>Chūkō shinsho ; 1728</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="ja-jpan">中公新書 ;</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/13694403instance14">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/13694403title17"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/4121017285"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9784121017284"/>
+      <bf:responsibilityStatement xml:lang="ja-jpan">星亮一著.</bf:responsibilityStatement>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Chūō Kōron Shinsha</bf:label>
+                  <bf:label xml:lang="ja-jpan">中央公論新社</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Tōkyō </bf:label>
+                  <bf:label xml:lang="ja-jpan">東京 :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>2003</bf:providerDate>
+            <bf:providerDate xml:lang="ja-jpan">2003.</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>iv, 202 , 4 p. :</bf:extent>
+      <bf:dimensions>18 cm.</bf:dimensions>
+      <bf:illustrationNote>ill., maps ;</bf:illustrationNote>
+      <bf:titleStatement>Aizu rakujō : Boshin Sensō saidai no higeki</bf:titleStatement>
+      <bf:providerStatement>Tōkyō : Chūō Kōron Shinsha, 2003.</bf:providerStatement>
+      <bf:supplementaryContentNote>Includes bibliographical references (p. 202).</bf:supplementaryContentNote>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2004701796</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>(CStRLIN)DCLP04-B11158</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/systemNumber"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:instanceOf rdf:resource="http://example.org/13694403"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/13694403annotation13">
+      <bf:derivedFrom rdf:resource="http://example.org/13694403.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlcr"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2007-08-24T23:46</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/13694403"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/13694403helditem32">
+      <bf:label>DS881.83 .H66 2003</bf:label>
+      <bf:shelfMarkLcc>DS881.83 .H66 2003</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/13694403instance14"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/13694403title5">
+      <bf:label> Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.</bf:label>
+      <bf:titleValue>Aizu rakujō :</bf:titleValue>
+      <bf:subtitle>Boshin Sensō saidai no higeki </bf:subtitle>
+      <bf:titleValue xml:lang="ja-jpan">会津落城 戊辰戦争最大の悲劇</bf:titleValue>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/13694403person6">
+      <bf:label>Hoshi, Ryōichi, 1935-</bf:label>
+      <bf:authorizedAccessPoint>Hoshi, Ryōichi, 1935-</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="ja-jpan">星亮一, 1935-</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hoshi, Ryōichi, 1935-</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Classification rdf:about="http://example.org/13694403classification10">
+      <bf:classificationScheme>njb/9</bf:classificationScheme>
+      <bf:classificationNumber>210.61</bf:classificationNumber>
+      <bf:label>210.61</bf:label>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/13694403title17">
+      <bf:label> Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.</bf:label>
+      <bf:titleValue>Aizu rakujō :</bf:titleValue>
+      <bf:subtitle>Boshin Sensō saidai no higeki </bf:subtitle>
+      <bf:titleValue xml:lang="ja-jpan">会津落城 戊辰戦争最大の悲劇</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/series/13694403.ttl
+++ b/spec/fixtures/loc/m2b-properties/series/13694403.ttl
@@ -1,0 +1,103 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/13694403annotation13> a bf:Annotation;
+   bf:annotates <http://example.org/13694403>;
+   bf:changeDate "2007-08-24T23:46";
+   bf:derivedFrom <http://example.org/13694403.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlcr>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/13694403helditem32> a bf:HeldItem;
+   bf:holdingFor <http://example.org/13694403instance14>;
+   bf:label "DS881.83 .H66 2003";
+   bf:shelfMarkLcc "DS881.83 .H66 2003" .
+
+<http://example.org/13694403classification10> a bf:Classification;
+   bf:classificationNumber "210.61";
+   bf:classificationScheme "njb/9";
+   bf:label "210.61" .
+
+<http://example.org/13694403instance14> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "18 cm.";
+   bf:extent "iv, 202 , 4 p. :";
+   bf:illustrationNote "ill., maps ;";
+   bf:instanceOf <http://example.org/13694403>;
+   bf:instanceTitle <http://example.org/13694403title17>;
+   bf:isbn10 <http://isbn.example.org/4121017285>;
+   bf:isbn13 <http://isbn.example.org/9784121017284>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2004701796"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:providerStatement "Tōkyō : Chūō Kōron Shinsha, 2003.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "2003",
+       "2003."@ja-jpan;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Chūō Kōron Shinsha",
+         "中央公論新社"@ja-jpan
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Tōkyō ",
+         "東京 :"@ja-jpan
+     ]
+   ];
+   bf:responsibilityStatement "星亮一著."@ja-jpan;
+   bf:supplementaryContentNote "Includes bibliographical references (p. 202).";
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:systemNumber;
+     bf:identifierValue "(CStRLIN)DCLP04-B11158"
+   ];
+   bf:titleStatement "Aizu rakujō : Boshin Sensō saidai no higeki" .
+
+<http://example.org/13694403person6> a bf:Person;
+   bf:authorizedAccessPoint "Hoshi, Ryōichi, 1935-",
+     "星亮一, 1935-"@ja-jpan;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hoshi, Ryōichi, 1935-"
+   ];
+   bf:label "Hoshi, Ryōichi, 1935-" .
+
+<http://example.org/13694403title17> a bf:Title;
+   bf:label " Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.";
+   bf:subtitle "Boshin Sensō saidai no higeki ";
+   bf:titleValue "Aizu rakujō :",
+     "会津落城 戊辰戦争最大の悲劇"@ja-jpan .
+
+<http://example.org/13694403title5> a bf:Title;
+   bf:label " Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.";
+   bf:subtitle "Boshin Sensō saidai no higeki ";
+   bf:titleValue "Aizu rakujō :",
+     "会津落城 戊辰戦争最大の悲劇"@ja-jpan .
+
+<http://example.org/13694403work11> a bf:Work;
+   bf:authorizedAccessPoint "Chūkō shinsho ; 1728",
+     "中公新書 ;"@ja-jpan;
+   bf:title "Chūkō shinsho ; 1728" .
+
+<http://example.org/13694403> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Hoshi, Ryōichi, 1935- Aizu rakujō : Boshin Sensō saidai no higeki / Hoshi Ryōichi cho.Aizu rakujō :Boshin Sensō saidai no higeki 会津落城 戊辰戦争最大の悲劇",
+     "hoshiryōichi1935aizurakujōboshinsensōsaidainohigekijpnworktext"@x-bf-hash;
+   bf:classification <http://example.org/13694403classification10>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/DS881.83>;
+   bf:creator <http://example.org/13694403person6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/jpn>;
+   bf:series <http://example.org/13694403work11>;
+   bf:subject <http://id.loc.gov/vocabulary/geographicAreas/a-ja>;
+   bf:workTitle <http://example.org/13694403title5> .

--- a/spec/fixtures/loc/m2b-properties/series/3599904.marcxml
+++ b/spec/fixtures/loc/m2b-properties/series/3599904.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01078cam a2200229   4500</leader>
   <controlfield tag="001">3599904</controlfield>
   <controlfield tag="005">19850313000000.0</controlfield>
@@ -66,4 +66,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3599904</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/series/3599904.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/series/3599904.rdfxml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/3599904">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Wells, John I. An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.An essay on warProving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/3599904title5"/>
+      <bf:title xml:lang="x-bf-sort">essay on war</bf:title>
+      <bf:creator rdf:resource="http://example.org/3599904person7"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/3599904topic9"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/BT736.2"/>
+      <bf:classificationDdc rdf:resource="http://dewey.info/class/261.8%2F73/about"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">wellsjohniessayonwarprovingthatthespiritofwarexistingintherationalmindiseverinimicaltothespiritofthegospelthatthewarsmentionedinthehistoryofthejewswereforthehappinessofthatpeoplethepunishmentofidolatrousnationsandtheinstructionofmankindgenerallyalsothatthespiritofwariswhollyexcludedfromthechristianchurchengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/3599904instance14">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/3599904title17"/>
+      <bf:title xml:lang="x-bf-sort">essay on war</bf:title>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>J. S. Ozer</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>New York</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1972]</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>52 p.</bf:extent>
+      <bf:dimensions>22 cm.</bf:dimensions>
+      <bf:titleStatement>An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church.</bf:titleStatement>
+      <bf:providerStatement>New York, J. S. Ozer, 1972</bf:providerStatement>
+      <bf:note>Facsim. reprint.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>70137560</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:instanceOf rdf:resource="http://example.org/3599904"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/3599904annotation13">
+      <bf:derivedFrom rdf:resource="http://example.org/3599904.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/nonisbd"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>1985-03-13T00:00</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/3599904"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/3599904helditem28">
+      <bf:label>BT736.2 .W42 1808a</bf:label>
+      <bf:shelfMarkLcc>BT736.2 .W42 1808a</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/3599904instance14"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/3599904title5">
+      <bf:label>An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.</bf:label>
+      <bf:titleValue>An essay on war</bf:titleValue>
+      <bf:subtitle>Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church.</bf:subtitle>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/3599904person7">
+      <bf:label>Wells, John I.</bf:label>
+      <bf:authorizedAccessPoint>Wells, John I.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Wells, John I.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Topic rdf:about="http://example.org/3599904topic9">
+      <bf:authorizedAccessPoint>War--Religious aspects--Christianity</bf:authorizedAccessPoint>
+      <bf:label>War--Religious aspects--Christianity</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>War--Religious aspects--Christianity</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>War</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>War</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Religious aspects</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Religious aspects</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Christianity</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Christianity.</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/3599904title17">
+      <bf:label>An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.</bf:label>
+      <bf:titleValue>An essay on war</bf:titleValue>
+      <bf:subtitle>Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church.</bf:subtitle>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/series/3599904.ttl
+++ b/spec/fixtures/loc/m2b-properties/series/3599904.ttl
@@ -1,0 +1,113 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/3599904annotation13> a bf:Annotation;
+   bf:annotates <http://example.org/3599904>;
+   bf:changeDate "1985-03-13T00:00";
+   bf:derivedFrom <http://example.org/3599904.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/nonisbd>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/3599904helditem28> a bf:HeldItem;
+   bf:holdingFor <http://example.org/3599904instance14>;
+   bf:label "BT736.2 .W42 1808a";
+   bf:shelfMarkLcc "BT736.2 .W42 1808a" .
+
+<http://example.org/3599904instance14> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "22 cm.";
+   bf:extent "52 p.";
+   bf:instanceOf <http://example.org/3599904>;
+   bf:instanceTitle <http://example.org/3599904title17>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "70137560"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:note "Facsim. reprint.";
+   bf:providerStatement "New York, J. S. Ozer, 1972";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1972]";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "J. S. Ozer"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "New York"
+     ]
+   ];
+   bf:title "essay on war"@x-bf-sort;
+   bf:titleStatement "An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church." .
+
+<http://example.org/3599904person7> a bf:Person;
+   bf:authorizedAccessPoint "Wells, John I.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Wells, John I."
+   ];
+   bf:label "Wells, John I." .
+
+<http://example.org/3599904title17> a bf:Title;
+   bf:label "An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.";
+   bf:subtitle "Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church.";
+   bf:titleValue "An essay on war" .
+
+<http://example.org/3599904title5> a bf:Title;
+   bf:label "An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.";
+   bf:subtitle "Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church.";
+   bf:titleValue "An essay on war" .
+
+<http://example.org/3599904topic9> a bf:Topic;
+   bf:authorizedAccessPoint "War--Religious aspects--Christianity";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "War--Religious aspects--Christianity";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "War";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "War"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Religious aspects";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Religious aspects"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Christianity";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Christianity."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "War--Religious aspects--Christianity" .
+
+<http://example.org/3599904> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Wells, John I. An essay on war. Proving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church. Hartford, Printed by Hudson and Goodwin, 1808.An essay on warProving that the spirit of war, existing in the rational mind, is ever inimical to the spirit of the Gospel; that the wars mentioned in the history of the Jews, were for the happiness of that people, the punishment of idolatrous nations, and the instruction of mankind generally. Also, that the spirit of war is wholly excluded from the Christian Church",
+     "wellsjohniessayonwarprovingthatthespiritofwarexistingintherationalmindiseverinimicaltothespiritofthegospelthatthewarsmentionedinthehistoryofthejewswereforthehappinessofthatpeoplethepunishmentofidolatrousnationsandtheinstructionofmankindgenerallyalsothatthespiritofwariswhollyexcludedfromthechristianchurchengworktext"@x-bf-hash;
+   bf:classificationDdc <http://dewey.info/class/261.8%2F73/about>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/BT736.2>;
+   bf:creator <http://example.org/3599904person7>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/3599904topic9>;
+   bf:title "essay on war"@x-bf-sort;
+   bf:workTitle <http://example.org/3599904title5> .

--- a/spec/fixtures/loc/m2b-properties/shelfMarkDdc/9746782.marcxml
+++ b/spec/fixtures/loc/m2b-properties/shelfMarkDdc/9746782.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01454cam a22003371  4500</leader>
   <controlfield tag="001">9746782</controlfield>
   <controlfield tag="005">20100614140304.0</controlfield>
@@ -101,4 +101,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=9746782</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/shelfMarkLcc/5456313.marcxml
+++ b/spec/fixtures/loc/m2b-properties/shelfMarkLcc/5456313.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00923cem a2200265 a 4500</leader>
   <controlfield tag="001">5456313</controlfield>
   <controlfield tag="005">20020524171250.0</controlfield>
@@ -78,4 +78,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">MAPS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5456313</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/shelfMarkLcc/6357877.marcxml
+++ b/spec/fixtures/loc/m2b-properties/shelfMarkLcc/6357877.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01141cam a22003011a 4500</leader>
   <controlfield tag="001">6357877</controlfield>
   <controlfield tag="005">20050128162925.0</controlfield>
@@ -92,4 +92,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">OCLCREP</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=6357877</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/shelfMarkScheme/13281648.marcxml
+++ b/spec/fixtures/loc/m2b-properties/shelfMarkScheme/13281648.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01383cam a2200337 a 4500</leader>
   <controlfield tag="001">13281648</controlfield>
   <controlfield tag="005">20031121111659.0</controlfield>
@@ -102,4 +102,4 @@
     <subfield code="h">ST/ESA/STAT/SER.F/89</subfield>
     <subfield code="2">localyale</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13281648</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/shelfMarkUdc/3555875.marcxml
+++ b/spec/fixtures/loc/m2b-properties/shelfMarkUdc/3555875.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01182cam a2200313 a 4500</leader>
   <controlfield tag="001">3555875</controlfield>
   <controlfield tag="005">20020923141759.0</controlfield>
@@ -92,4 +92,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3555875</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/splitInto/11185095.marcxml
+++ b/spec/fixtures/loc/m2b-properties/splitInto/11185095.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02048cas a2200457 a 4500</leader>
   <controlfield tag="001">11185095</controlfield>
   <controlfield tag="005">20121213075511.0</controlfield>
@@ -144,4 +144,4 @@
     <subfield code="b">B/L</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11185095</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/splitInto/11185095.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/splitInto/11185095.rdfxml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11185095">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Karnataka (India) Detailed estimates of irrigation, electricity, and public works for the year ...Detailed estimates of irrigation, electricity, and public works for the year .</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11185095title5"/>
+      <bf:creator rdf:resource="http://example.org/11185095jurisdiction6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/kan"/>
+      <bf:subject rdf:resource="http://example.org/11185095topic9"/>
+      <bf:subject rdf:resource="http://example.org/11185095topic10"/>
+      <bf:subject rdf:resource="http://example.org/11185095topic11"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/a-ii"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/HD1741.I3"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/HD4295.M8"/>
+      <bf:continues rdf:resource="http://example.org/11185095work15"/>
+      <bf:splitInto rdf:resource="http://example.org/11185095work16"/>
+      <bf:splitInto rdf:resource="http://example.org/11185095work17"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">karnatakaindiadetailedestimatesofirrigationelectricityandpublicworksfortheyearengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11185095work15">
+      <bf:title>Detailed estimates of irrigation, electricity, and public works</bf:title>
+      <bf:authorizedAccessPoint>Mysore (India : State). Detailed estimates of irrigation, electricity, and public works</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/11185095agent19"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11185095work16">
+      <bf:title>Nīrāvariya savivara andājugaḷu</bf:title>
+      <bf:authorizedAccessPoint>Karnataka (India). Nīrāvariya savivara andājugaḷu</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/99936362"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/41592709"/>
+      <bf:contributor rdf:resource="http://example.org/11185095agent22"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11185095work17">
+      <bf:title>Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu</bf:title>
+      <bf:authorizedAccessPoint>Karnataka (India). Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2002294797"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/51281493"/>
+      <bf:contributor rdf:resource="http://example.org/11185095agent23"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11185095instance20">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11185095title23"/>
+      <bf:titleVariation rdf:resource="http://example.org/11185095title24"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Director of Print., Stationery, and Publications</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Bangalore </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. ;</bf:extent>
+      <bf:dimensions>30 cm.</bf:dimensions>
+      <bf:titleStatement>Detailed estimates of irrigation, electricity, and public works for the year ...</bf:titleStatement>
+      <bf:providerStatement>Bangalore : Director of Print., Stationery, and Publications</bf:providerStatement>
+      <bf:frequencyNote>Annual</bf:frequencyNote>
+      <bf:languageNote>English or Kannada.</bf:languageNote>
+      <bf:note>Split into: Karnataka (India). Nīrāvariya savivara andājugaḷu, and: Karnataka (India). Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu.</bf:note>
+      <bf:note>Description based on: 1976-77.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>74901206</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/05112447"/>
+      <bf:serialFirstIssue>Began with issue for 1974-75.</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11185095"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11185095annotation19">
+      <bf:derivedFrom rdf:resource="http://example.org/11185095.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/iu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mnmuls"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dnal"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2012-12-13T07:55</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11185095"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11185095helditem40">
+      <bf:label>HD1741.I3 M9</bf:label>
+      <bf:shelfMarkLcc>HD1741.I3 M9</bf:shelfMarkLcc>
+      <bf:shelfMarkLcc>HD4295.M8 A2</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11185095instance20"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11185095title5">
+      <bf:label>Detailed estimates of irrigation, electricity, and public works for the year ...</bf:label>
+      <bf:titleValue>Detailed estimates of irrigation, electricity, and public works for the year ..</bf:titleValue>
+   </bf:Title>
+   <bf:Jurisdiction rdf:about="http://example.org/11185095jurisdiction6">
+      <bf:label>Karnataka (India)</bf:label>
+      <bf:authorizedAccessPoint>Karnataka (India)</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Karnataka (India)</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Topic rdf:about="http://example.org/11185095topic9">
+      <bf:authorizedAccessPoint>Irrigation--Estimates--India--Karnataka--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Irrigation--Estimates--India--Karnataka--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Irrigation--Estimates--India--Karnataka--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Irrigation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Irrigation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Estimates</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Estimates</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>India</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>India</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Karnataka</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Karnataka</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11185095topic10">
+      <bf:authorizedAccessPoint>Public works--Estimates--India--Karnataka--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Public works--Estimates--India--Karnataka--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Public works--Estimates--India--Karnataka--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Public works</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Public works</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Estimates</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Estimates</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>India</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>India</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Karnataka</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Karnataka</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11185095topic11">
+      <bf:authorizedAccessPoint>Irrigation--India--Karnataka</bf:authorizedAccessPoint>
+      <bf:label>Irrigation--India--Karnataka</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Irrigation--India--Karnataka</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Irrigation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Irrigation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>India</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>India</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Karnataka</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Karnataka.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Agent rdf:about="http://example.org/11185095agent19">
+      <bf:label>Mysore (India : State).</bf:label>
+      <bf:authorizedAccessPoint>Mysore (India : State).</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Mysore (India : State).</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/11185095agent22">
+      <bf:label>Karnataka (India).</bf:label>
+      <bf:authorizedAccessPoint>Karnataka (India).</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Karnataka (India).</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/11185095agent23">
+      <bf:label>Karnataka (India).</bf:label>
+      <bf:authorizedAccessPoint>Karnataka (India).</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Karnataka (India).</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/11185095title23">
+      <bf:label>Detailed estimates of irrigation, electricity, and public works for the year ...</bf:label>
+      <bf:titleValue>Detailed estimates of irrigation, electricity, and public works for the year ..</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11185095title24">
+      <bf:label>Nīrāvarī, vidyucchakti, mattu lōkōpayōgī kāmagārigaḷa savivara andājugaḷu &lt;1976-77-1980-81&gt;</bf:label>
+      <bf:titleValue>Nīrāvarī, vidyucchakti, mattu lōkōpayōgī kāmagārigaḷa savivara andājugaḷu</bf:titleValue>
+      <bf:titleVariationDate>&lt;1976-77-1980-81&gt;</bf:titleVariationDate>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/splitInto/11185095.ttl
+++ b/spec/fixtures/loc/m2b-properties/splitInto/11185095.ttl
@@ -1,0 +1,278 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11185095annotation19> a bf:Annotation;
+   bf:annotates <http://example.org/11185095>;
+   bf:changeDate "2012-12-13T07:55";
+   bf:derivedFrom <http://example.org/11185095.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/mnmuls>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/dnal>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/iu>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11185095helditem40> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11185095instance20>;
+   bf:label "HD1741.I3 M9";
+   bf:shelfMarkLcc "HD1741.I3 M9",
+     "HD4295.M8 A2" .
+
+<http://example.org/11185095agent19> a bf:Agent;
+   bf:authorizedAccessPoint "Mysore (India : State).";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Mysore (India : State)."
+   ];
+   bf:label "Mysore (India : State)." .
+
+<http://example.org/11185095agent22> a bf:Agent;
+   bf:authorizedAccessPoint "Karnataka (India).";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Karnataka (India)."
+   ];
+   bf:label "Karnataka (India)." .
+
+<http://example.org/11185095agent23> a bf:Agent;
+   bf:authorizedAccessPoint "Karnataka (India).";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Karnataka (India)."
+   ];
+   bf:label "Karnataka (India)." .
+
+<http://example.org/11185095instance20> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "30 cm.";
+   bf:extent "v. ;";
+   bf:frequencyNote "Annual";
+   bf:instanceOf <http://example.org/11185095>;
+   bf:instanceTitle <http://example.org/11185095title23>;
+   bf:languageNote "English or Kannada.";
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "74901206"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Split into: Karnataka (India). Nīrāvariya savivara andājugaḷu, and: Karnataka (India). Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu.",
+     "Description based on: 1976-77.",
+     "SERBIB/SERLOC merged record";
+   bf:providerStatement "Bangalore : Director of Print., Stationery, and Publications";
+   bf:publication [
+     a bf:Provider;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Director of Print., Stationery, and Publications"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Bangalore "
+     ]
+   ];
+   bf:serialFirstIssue "Began with issue for 1974-75.";
+   bf:systemNumber <http://www.worldcat.org/oclc/05112447>;
+   bf:titleStatement "Detailed estimates of irrigation, electricity, and public works for the year ...";
+   bf:titleVariation <http://example.org/11185095title24> .
+
+<http://example.org/11185095jurisdiction6> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Karnataka (India)";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Karnataka (India)"
+   ];
+   bf:label "Karnataka (India)" .
+
+<http://example.org/11185095title23> a bf:Title;
+   bf:label "Detailed estimates of irrigation, electricity, and public works for the year ...";
+   bf:titleValue "Detailed estimates of irrigation, electricity, and public works for the year .." .
+
+<http://example.org/11185095title24> a bf:Title;
+   bf:label "Nīrāvarī, vidyucchakti, mattu lōkōpayōgī kāmagārigaḷa savivara andājugaḷu <1976-77-1980-81>";
+   bf:titleValue "Nīrāvarī, vidyucchakti, mattu lōkōpayōgī kāmagārigaḷa savivara andājugaḷu";
+   bf:titleVariationDate "<1976-77-1980-81>" .
+
+<http://example.org/11185095title5> a bf:Title;
+   bf:label "Detailed estimates of irrigation, electricity, and public works for the year ...";
+   bf:titleValue "Detailed estimates of irrigation, electricity, and public works for the year .." .
+
+<http://example.org/11185095topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Public works--Estimates--India--Karnataka--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Public works--Estimates--India--Karnataka--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Public works";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Public works"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Estimates";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Estimates"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "India";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "India"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Karnataka";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Karnataka"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Public works--Estimates--India--Karnataka--Periodicals" .
+
+<http://example.org/11185095topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Irrigation--India--Karnataka";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Irrigation--India--Karnataka";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Irrigation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Irrigation"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "India";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "India"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Karnataka";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Karnataka."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Irrigation--India--Karnataka" .
+
+<http://example.org/11185095topic9> a bf:Topic;
+   bf:authorizedAccessPoint "Irrigation--Estimates--India--Karnataka--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Irrigation--Estimates--India--Karnataka--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Irrigation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Irrigation"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Estimates";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Estimates"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "India";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "India"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Karnataka";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Karnataka"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Irrigation--Estimates--India--Karnataka--Periodicals" .
+
+<http://example.org/11185095work15> a bf:Work;
+   bf:authorizedAccessPoint "Mysore (India : State). Detailed estimates of irrigation, electricity, and public works";
+   bf:contributor <http://example.org/11185095agent19>;
+   bf:title "Detailed estimates of irrigation, electricity, and public works" .
+
+<http://example.org/11185095work16> a bf:Work;
+   bf:authorizedAccessPoint "Karnataka (India). Nīrāvariya savivara andājugaḷu";
+   bf:contributor <http://example.org/11185095agent22>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/99936362>;
+   bf:systemNumber <http://www.worldcat.org/oclc/41592709>;
+   bf:title "Nīrāvariya savivara andājugaḷu" .
+
+<http://example.org/11185095work17> a bf:Work;
+   bf:authorizedAccessPoint "Karnataka (India). Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu";
+   bf:contributor <http://example.org/11185095agent23>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2002294797>;
+   bf:systemNumber <http://www.worldcat.org/oclc/51281493>;
+   bf:title "Lōkōpayōgi kāmagāṅgaḷa savivara andājugaḷu" .
+
+<http://example.org/11185095> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Karnataka (India) Detailed estimates of irrigation, electricity, and public works for the year ...Detailed estimates of irrigation, electricity, and public works for the year .",
+     "karnatakaindiadetailedestimatesofirrigationelectricityandpublicworksfortheyearengworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/HD1741.I3>,
+     <http://id.loc.gov/authorities/classification/HD4295.M8>;
+   bf:continues <http://example.org/11185095work15>;
+   bf:creator <http://example.org/11185095jurisdiction6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>,
+     <http://id.loc.gov/vocabulary/languages/kan>;
+   bf:splitInto <http://example.org/11185095work16>,
+     <http://example.org/11185095work17>;
+   bf:subject <http://example.org/11185095topic9>,
+     <http://example.org/11185095topic10>,
+     <http://example.org/11185095topic11>,
+     <http://id.loc.gov/vocabulary/geographicAreas/a-ii>;
+   bf:workTitle <http://example.org/11185095title5> .

--- a/spec/fixtures/loc/m2b-properties/stockNumber/12402887.marcxml
+++ b/spec/fixtures/loc/m2b-properties/stockNumber/12402887.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01227cam a2200313 a 4500</leader>
   <controlfield tag="001">12402887</controlfield>
   <controlfield tag="005">20020312135428.0</controlfield>
@@ -92,4 +92,4 @@
     <subfield code="o">am</subfield>
     <subfield code="p">00071040768</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12402887</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/strn/13466744.marcxml
+++ b/spec/fixtures/loc/m2b-properties/strn/13466744.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01991cam a22004217a 4500</leader>
   <controlfield tag="001">13466744</controlfield>
   <controlfield tag="005">20060321171044.0</controlfield>
@@ -121,4 +121,4 @@
   <datafield tag="856" ind1="4" ind2="1">
     <subfield code="u">http://www.cami.jccbi.gov//aam-400A/Abstracts/2003/FULL%20TEXT/0319.pdf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13466744</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/studyNumber/12249558.marcxml
+++ b/spec/fixtures/loc/m2b-properties/studyNumber/12249558.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01269cam a22003497a 4500</leader>
   <controlfield tag="001">12249558</controlfield>
   <controlfield tag="005">20010404135544.0</controlfield>
@@ -99,4 +99,4 @@
   <datafield tag="830" ind1=" " ind2="0">
     <subfield code="a">Tourisme (Presses de l'Universite&#x301; du Que&#x301;bec)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12249558</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/subLocation/16530652.marcxml
+++ b/spec/fixtures/loc/m2b-properties/subLocation/16530652.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03995ckd a2200637 a 4500</leader>
   <controlfield tag="001">16530652</controlfield>
   <controlfield tag="005">20110616095858.0</controlfield>
@@ -212,4 +212,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="m">(H)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16530652</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/subject/11160818.marcxml
+++ b/spec/fixtures/loc/m2b-properties/subject/11160818.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04626cas a2200901 a 4500</leader>
   <controlfield tag="001">11160818</controlfield>
   <controlfield tag="005">20140507170644.0</controlfield>
@@ -438,4 +438,4 @@
     <subfield code="b">Ser</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11160818</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/subject/11160818.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/subject/11160818.rdfxml
@@ -1,0 +1,527 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11160818">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>American Chemical Society. Environmental science &amp; technology (Easton, Pa.)</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Environmental science &amp; technology (Easton, Pa.)</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/11160818title6"/>
+      <bf:contributor rdf:resource="http://example.org/11160818organization7"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>0013-936X</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:supplementaryContentNote>Some issues for &lt;1972-Feb. 1991&gt; accompanied by supplementary material on microfiche; Mar. 1995-1998 by supporting information on microfiche; supporting information available only online after 1998.</bf:supplementaryContentNote>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic11"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic12"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic13"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic14"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic15"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic16"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic17"/>
+      <bf:subject rdf:resource="http://example.org/11160818topic18"/>
+      <bf:classificationNlm rdf:resource="http://nlm.example.org/classification/W1"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/TD180"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/TP1"/>
+      <bf:classificationDdc rdf:resource="http://dewey.info/class/628%2F.5%2F05/about"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>0013-936X</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:absorbed rdf:resource="http://example.org/11160818work24"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">americanchemicalsocietyenvironmentalsciencetechnologyeastonpaengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11160818work24">
+      <bf:title>Environmental buyers' guide</bf:title>
+      <bf:authorizedAccessPoint>Environmental buyers' guide</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:1068-4980"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/93648173"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/22605922"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11160818instance27">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11160818title30"/>
+      <bf:keyTitle rdf:resource="http://example.org/11160818title31"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11160818title32"/>
+      <bf:titleVariation rdf:resource="http://example.org/11160818title33"/>
+      <bf:titleVariation rdf:resource="http://example.org/11160818title34"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>American Chemical Society</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Easton, Pa. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:copyrightDate>c1967-</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11160818instance37"/>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11160818instance38"/>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>29 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. (some col.), ports. ;</bf:illustrationNote>
+      <bf:titleStatement>Environmental science &amp; technology.</bf:titleStatement>
+      <bf:providerStatement>Easton, Pa. : American Chemical Society, c1967-</bf:providerStatement>
+      <bf:frequencyNote>Semimonthly, 1998-</bf:frequencyNote>
+      <bf:note>Title from cover.</bf:note>
+      <bf:note>One issue annually, Sept. 1993- consists of the 1994- Environmental buyers' guide edition.</bf:note>
+      <bf:note>Published: Washington, DC, &lt;Sept. 1993- &gt;</bf:note>
+      <bf:note>Chemical abstracts</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:note>ACQN: aq 94014037</bf:note>
+      <bf:note>13 no. a year,</bf:note>
+      <bf:note>FRO Vendor change</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>68005797</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+            <bf:identifierValue>sn 95020206</bf:identifierValue>
+            <bf:identifierStatus>canceled/invalid</bf:identifierStatus>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>E10680000</bf:identifierValue>
+            <bf:identifierAssigner>DNLM</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>0213155</bf:identifierValue>
+            <bf:identifierAssigner>DNLM</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>0013-936X</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:coden>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/coden"/>
+            <bf:identifierValue>ESTHAG</bf:identifierValue>
+         </bf:Identifier>
+      </bf:coden>
+      <bf:postalRegistration>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/postalRegistration"/>
+            <bf:identifierValue>177660</bf:identifierValue>
+            <bf:identifierAssigner>USPS</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:postalRegistration>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/01568096"/>
+      <bf:identifier>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/coden"/>
+            <bf:identifierValue>ESTHAG</bf:identifierValue>
+         </bf:Identifier>
+      </bf:identifier>
+      <bf:serialFirstIssue>Vol. 1, no. 1 (Jan. 1967)</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11160818"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11160818instance37">
+      <bf:title>Environmental science &amp; technology (Easton, Pa. : Online)</bf:title>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>sn 98004602</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/36773586"/>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierValue>1520-5851</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+         </bf:Identifier>
+      </bf:issn>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11160818instance38">
+      <bf:title>Environmental science &amp; technology (Easton, Pa.)</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/685248727"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11160818instance28">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <bf:label>Electronic Resource</bf:label>
+      <bf:uri rdf:resource="http://pubs.acs.org/journals/esthag/index.html"/>
+      <bf:instanceOf rdf:resource="http://example.org/11160818"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11160818annotation26">
+      <bf:derivedFrom rdf:resource="http://example.org/11160818.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/mul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/vrc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/udi"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ser"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/rcs"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/aip"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/aip"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/iul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/hul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/iul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/agl"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/myg"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nyg"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/hul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsd"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/myg"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/iul"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nlm"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/gua"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclcq"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nlggc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/gua"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/lvb"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/cui"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclcq"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/deh"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/amazn"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/cud"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/upm"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclcf"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/p4i"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2014-05-07T17:06</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11160818"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11160818helditem64">
+      <bf:label>TD180 .E5</bf:label>
+      <bf:shelfMarkLcc>TD180 .E5</bf:shelfMarkLcc>
+      <bf:shelfMarkLcc>TP1 .E5</bf:shelfMarkLcc>
+      <bf:shelfMarkNlm>W1 EN985S</bf:shelfMarkNlm>
+      <bf:holdingFor rdf:resource="http://example.org/11160818instance27"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11160818title6">
+      <bf:titleValue>Environmental science &amp; technology (Easton, Pa.)</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/11160818organization7">
+      <bf:label>American Chemical Society.</bf:label>
+      <bf:authorizedAccessPoint>American Chemical Society.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>American Chemical Society.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11160818topic11">
+      <bf:authorizedAccessPoint>Pollution--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Pollution--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Pollution--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Pollution</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Pollution</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic12">
+      <bf:authorizedAccessPoint>Sanitary chemistry--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Sanitary chemistry--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Sanitary chemistry--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Sanitary chemistry</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Sanitary chemistry</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic13">
+      <bf:authorizedAccessPoint>Environmental engineering--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Environmental engineering--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Environmental engineering--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Environmental engineering</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Environmental engineering</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic14">
+      <bf:authorizedAccessPoint>Environmental Health--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Environmental Health--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Environmental Health--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/mesh"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Environmental Health</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Environmental Health</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic15">
+      <bf:authorizedAccessPoint>Sanitation--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Sanitation--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Sanitation--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/vocabulary/subjectSchemes/mesh"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Sanitation</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Sanitation</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic16">
+      <bf:authorizedAccessPoint>Pollution--Périodiques</bf:authorizedAccessPoint>
+      <bf:label>Pollution--Périodiques</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Pollution--Périodiques</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Pollution</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Pollution</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Périodiques</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Périodiques.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic17">
+      <bf:authorizedAccessPoint>Environnement, Technique de l'--Périodiques</bf:authorizedAccessPoint>
+      <bf:label>Environnement, Technique de l'--Périodiques</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Environnement, Technique de l'--Périodiques</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Environnement, Technique de l'</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Environnement, Technique de l'</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Périodiques</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Périodiques.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11160818topic18">
+      <bf:authorizedAccessPoint>Chimie sanitaire--Périodiques</bf:authorizedAccessPoint>
+      <bf:label>Chimie sanitaire--Périodiques</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Chimie sanitaire--Périodiques</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Chimie sanitaire</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Chimie sanitaire</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Périodiques</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Périodiques.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11160818title30">
+      <bf:label>Environ. sci. technol.</bf:label>
+      <bf:titleValue>Environ. sci. technol.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11160818title31">
+      <bf:label>Environmental science &amp; technology</bf:label>
+      <bf:titleValue>Environmental science &amp; technology</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11160818title32">
+      <bf:label>Environmental science &amp; technology.</bf:label>
+      <bf:titleValue>Environmental science &amp; technology</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11160818title33">
+      <bf:label>ES &amp; T Jan. 1978-</bf:label>
+      <bf:titleValue>ES &amp; T</bf:titleValue>
+      <bf:titleVariationDate>Jan. 1978-</bf:titleVariationDate>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11160818title34">
+      <bf:titleType>running</bf:titleType>
+      <bf:label>Environmental science and technology</bf:label>
+      <bf:titleValue>Environmental science and technology</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/subject/11160818.ttl
+++ b/spec/fixtures/loc/m2b-properties/subject/11160818.ttl
@@ -1,0 +1,446 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11160818annotation26> a bf:Annotation;
+   bf:annotates <http://example.org/11160818>;
+   bf:changeDate "2014-05-07T17:06";
+   bf:derivedFrom <http://example.org/11160818.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/nsd>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/vrc>,
+     <http://id.loc.gov/vocabulary/organizations/mul>,
+     <http://id.loc.gov/vocabulary/organizations/udi>,
+     <http://id.loc.gov/vocabulary/organizations/ocl>,
+     <http://id.loc.gov/vocabulary/organizations/ser>,
+     <http://id.loc.gov/vocabulary/organizations/rcs>,
+     <http://id.loc.gov/vocabulary/organizations/aip>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/iul>,
+     <http://id.loc.gov/vocabulary/organizations/hul>,
+     <http://id.loc.gov/vocabulary/organizations/agl>,
+     <http://id.loc.gov/vocabulary/organizations/myg>,
+     <http://id.loc.gov/vocabulary/organizations/nyg>,
+     <http://id.loc.gov/vocabulary/organizations/nlm>,
+     <http://id.loc.gov/vocabulary/organizations/gua>,
+     <http://id.loc.gov/vocabulary/organizations/oclcq>,
+     <http://id.loc.gov/vocabulary/organizations/nlggc>,
+     <http://id.loc.gov/vocabulary/organizations/lvb>,
+     <http://id.loc.gov/vocabulary/organizations/cui>,
+     <http://id.loc.gov/vocabulary/organizations/deh>,
+     <http://id.loc.gov/vocabulary/organizations/amazn>,
+     <http://id.loc.gov/vocabulary/organizations/cud>,
+     <http://id.loc.gov/vocabulary/organizations/upm>,
+     <http://id.loc.gov/vocabulary/organizations/oclcf>,
+     <http://id.loc.gov/vocabulary/organizations/p4i>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/mul>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11160818helditem64> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11160818instance27>;
+   bf:label "TD180 .E5";
+   bf:shelfMarkLcc "TD180 .E5",
+     "TP1 .E5";
+   bf:shelfMarkNlm "W1 EN985S" .
+
+<http://example.org/11160818instance28> a bf:Instance,
+     bf:Electronic;
+   bf:instanceOf <http://example.org/11160818>;
+   bf:label "Electronic Resource";
+   bf:uri <http://pubs.acs.org/journals/esthag/index.html> .
+
+<http://example.org/11160818instance27> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11160818title30>;
+   bf:coden [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:coden;
+     bf:identifierValue "ESTHAG"
+   ];
+   bf:dimensions "29 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Semimonthly, 1998-";
+   bf:identifier [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:coden;
+     bf:identifierValue "ESTHAG"
+   ];
+   bf:illustrationNote "ill. (some col.), ports. ;";
+   bf:instanceOf <http://example.org/11160818>;
+   bf:instanceTitle <http://example.org/11160818title32>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "0013-936X"
+   ];
+   bf:keyTitle <http://example.org/11160818title31>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "68005797"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierStatus "canceled/invalid";
+     bf:identifierValue "sn 95020206"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:nban [
+     a bf:Identifier;
+     bf:identifierAssigner "DNLM";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "E10680000"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "DNLM";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "0213155"
+   ];
+   bf:note "Title from cover.",
+     "One issue annually, Sept. 1993- consists of the 1994- Environmental buyers' guide edition.",
+     "Published: Washington, DC, <Sept. 1993- >",
+     "Chemical abstracts",
+     "SERBIB/SERLOC merged record",
+     "ACQN: aq 94014037",
+     "13 no. a year,",
+     "FRO Vendor change";
+   bf:otherPhysicalFormat <http://example.org/11160818instance37>,
+     <http://example.org/11160818instance38>;
+   bf:postalRegistration [
+     a bf:Identifier;
+     bf:identifierAssigner "USPS";
+     bf:identifierScheme loc_ids:postalRegistration;
+     bf:identifierValue "177660"
+   ];
+   bf:providerStatement "Easton, Pa. : American Chemical Society, c1967-";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "c1967-";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "American Chemical Society"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Easton, Pa. "
+     ]
+   ];
+   bf:serialFirstIssue "Vol. 1, no. 1 (Jan. 1967)";
+   bf:systemNumber <http://www.worldcat.org/oclc/01568096>;
+   bf:titleStatement "Environmental science & technology.";
+   bf:titleVariation <http://example.org/11160818title33>,
+     <http://example.org/11160818title34> .
+
+<http://example.org/11160818instance37> a bf:Instance;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "1520-5851"
+   ];
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sn 98004602"
+   ],
+     <http://www.worldcat.org/oclc/36773586>;
+   bf:title "Environmental science & technology (Easton, Pa. : Online)" .
+
+<http://example.org/11160818instance38> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/685248727>;
+   bf:title "Environmental science & technology (Easton, Pa.)" .
+
+<http://example.org/11160818organization7> a bf:Organization;
+   bf:authorizedAccessPoint "American Chemical Society.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "American Chemical Society."
+   ];
+   bf:label "American Chemical Society." .
+
+<http://example.org/11160818title30> a bf:Title;
+   bf:label "Environ. sci. technol.";
+   bf:titleValue "Environ. sci. technol." .
+
+<http://example.org/11160818title31> a bf:Title;
+   bf:label "Environmental science & technology";
+   bf:titleValue "Environmental science & technology" .
+
+<http://example.org/11160818title32> a bf:Title;
+   bf:label "Environmental science & technology.";
+   bf:titleValue "Environmental science & technology" .
+
+<http://example.org/11160818title33> a bf:Title;
+   bf:label "ES & T Jan. 1978-";
+   bf:titleValue "ES & T";
+   bf:titleVariationDate "Jan. 1978-" .
+
+<http://example.org/11160818title34> a bf:Title;
+   bf:label "Environmental science and technology";
+   bf:titleType "running";
+   bf:titleValue "Environmental science and technology" .
+
+<http://example.org/11160818title6> a bf:Title;
+   bf:titleValue "Environmental science & technology (Easton, Pa.)" .
+
+<http://example.org/11160818topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Pollution--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Pollution--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Pollution";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Pollution"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Pollution--Periodicals" .
+
+<http://example.org/11160818topic12> a bf:Topic;
+   bf:authorizedAccessPoint "Sanitary chemistry--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Sanitary chemistry--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Sanitary chemistry";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Sanitary chemistry"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Sanitary chemistry--Periodicals" .
+
+<http://example.org/11160818topic13> a bf:Topic;
+   bf:authorizedAccessPoint "Environmental engineering--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Environmental engineering--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Environmental engineering";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Environmental engineering"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Environmental engineering--Periodicals" .
+
+<http://example.org/11160818topic14> a bf:Topic;
+   bf:authorizedAccessPoint "Environmental Health--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Environmental Health--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Environmental Health";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Environmental Health"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/mesh>
+   ];
+   bf:label "Environmental Health--Periodicals" .
+
+<http://example.org/11160818topic15> a bf:Topic;
+   bf:authorizedAccessPoint "Sanitation--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Sanitation--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Sanitation";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Sanitation"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/vocabulary/subjectSchemes/mesh>
+   ];
+   bf:label "Sanitation--Periodicals" .
+
+<http://example.org/11160818topic16> a bf:Topic;
+   bf:authorizedAccessPoint "Pollution--Périodiques";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Pollution--Périodiques";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Pollution";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Pollution"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Périodiques";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Périodiques."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Pollution--Périodiques" .
+
+<http://example.org/11160818topic17> a bf:Topic;
+   bf:authorizedAccessPoint "Environnement, Technique de l'--Périodiques";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Environnement, Technique de l'--Périodiques";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Environnement, Technique de l'";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Environnement, Technique de l'"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Périodiques";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Périodiques."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Environnement, Technique de l'--Périodiques" .
+
+<http://example.org/11160818topic18> a bf:Topic;
+   bf:authorizedAccessPoint "Chimie sanitaire--Périodiques";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Chimie sanitaire--Périodiques";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Chimie sanitaire";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Chimie sanitaire"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Périodiques";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Périodiques."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Chimie sanitaire--Périodiques" .
+
+<http://example.org/11160818work24> a bf:Work;
+   bf:authorizedAccessPoint "Environmental buyers' guide";
+   bf:issn <urn:issn:1068-4980>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/93648173>;
+   bf:systemNumber <http://www.worldcat.org/oclc/22605922>;
+   bf:title "Environmental buyers' guide" .
+
+<http://example.org/11160818> a bf:Work,
+     bf:Text;
+   bf:absorbed <http://example.org/11160818work24>;
+   bf:authorizedAccessPoint "American Chemical Society. Environmental science & technology (Easton, Pa.)",
+     "americanchemicalsocietyenvironmentalsciencetechnologyeastonpaengworktext"@x-bf-hash;
+   bf:classificationDdc <http://dewey.info/class/628%2F.5%2F05/about>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/TD180>,
+     <http://id.loc.gov/authorities/classification/TP1>;
+   bf:classificationNlm <http://nlm.example.org/classification/W1>;
+   bf:contributor <http://example.org/11160818organization7>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0013-936X"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0013-936X"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/11160818topic11>,
+     <http://example.org/11160818topic12>,
+     <http://example.org/11160818topic13>,
+     <http://example.org/11160818topic14>,
+     <http://example.org/11160818topic15>,
+     <http://example.org/11160818topic16>,
+     <http://example.org/11160818topic17>,
+     <http://example.org/11160818topic18>;
+   bf:supplementaryContentNote "Some issues for <1972-Feb. 1991> accompanied by supplementary material on microfiche; Mar. 1995-1998 by supporting information on microfiche; supporting information available only online after 1998.";
+   bf:workTitle <http://example.org/11160818title6>;
+   mads:authoritativeLabel "Environmental science & technology (Easton, Pa.)" .

--- a/spec/fixtures/loc/m2b-properties/subseries/11292563.marcxml
+++ b/spec/fixtures/loc/m2b-properties/subseries/11292563.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01663cas a2200397 a 4500</leader>
   <controlfield tag="001">11292563</controlfield>
   <controlfield tag="005">20121213084552.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="i">.N2842</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11292563</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/subseries/11292563.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/subseries/11292563.rdfxml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11292563">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao. Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11292563title5"/>
+      <bf:contributor rdf:resource="http://example.org/11292563organization6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/dut"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11292563topic9"/>
+      <bf:subject rdf:resource="http://example.org/11292563topic10"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/QH7"/>
+      <bf:continuedBy rdf:resource="http://example.org/11292563work12"/>
+      <bf:subseries rdf:resource="http://example.org/11292563work13"/>
+      <bf:subseries rdf:resource="http://example.org/11292563work14"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">natuurwetenschappelijkestudiekringvoorsurinameencuraçaouitgavenvandestichtingnatuurwetenschappelijkestudiekringvoorsurinameencuraçaodutworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11292563work12">
+      <bf:title>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en de Nederlandse Antillen"</bf:title>
+      <bf:authorizedAccessPoint>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en de Nederlandse Antillen"</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0300-5534"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/54027432"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/1388681"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11292563work13">
+      <bf:title>Jaarboek - Natuurwetenschappelijke Studiekring voor Suriname en Curaçao</bf:title>
+      <bf:authorizedAccessPoint>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao. Jaarboek - Natuurwetenschappelijke Studiekring voor Suriname en Curaçao</bf:authorizedAccessPoint>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/5981961"/>
+      <bf:contributor rdf:resource="http://example.org/11292563agent18"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11292563work14">
+      <bf:title>Studies on the fauna of Curaçao, Aruba, Bonaire and the Venezuelan Islands</bf:title>
+      <bf:authorizedAccessPoint>Studies on the fauna of Curaçao, Aruba, Bonaire and the Venezuelan Islands</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/73615350"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/2607544"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11292563instance17">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11292563title20"/>
+      <bf:titleVariation rdf:resource="http://example.org/11292563title21"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>De Studiekring</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Utrecht </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1946-1948</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>5 v. :</bf:extent>
+      <bf:dimensions>25 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:titleStatement>
+      <bf:providerStatement>Utrecht : De Studiekring, 1946-1948.</bf:providerStatement>
+      <bf:frequencyNote>Irregular</bf:frequencyNote>
+      <bf:languageNote>Dutch and English.</bf:languageNote>
+      <bf:note>Title varies slightly.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sf 85004161</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:nbn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nbn"/>
+            <bf:identifierValue>015286398</bf:identifierValue>
+            <bf:identifierAssigner>dnb</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nbn>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>990791--9</bf:identifierValue>
+            <bf:identifierAssigner>DE-600</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>015286398</bf:identifierValue>
+            <bf:identifierAssigner>DE-101</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>9907919</bf:identifierValue>
+            <bf:identifierAssigner>DE-600</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/05909923"/>
+      <bf:serialFirstIssue>No. 1</bf:serialFirstIssue>
+      <bf:serialLastIssue>no. 5.</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11292563"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11292563annotation16">
+      <bf:derivedFrom rdf:resource="http://example.org/11292563.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/mh"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/wau"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/hebis"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/gbvcp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2012-12-13T08:45</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11292563"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11292563helditem41">
+      <bf:label>QH7 .N2842</bf:label>
+      <bf:shelfMarkLcc>QH7 .N2842</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11292563instance17"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11292563title5">
+      <bf:label>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:label>
+      <bf:titleValue>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/11292563organization6">
+      <bf:label>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</bf:label>
+      <bf:authorizedAccessPoint>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11292563topic9">
+      <bf:authorizedAccessPoint>Natural history</bf:authorizedAccessPoint>
+      <bf:label>Natural history</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
+            <madsrdf:authoritativeLabel>Natural history</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11292563topic10">
+      <bf:authorizedAccessPoint>Agriculture</bf:authorizedAccessPoint>
+      <bf:label>Agriculture</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
+            <madsrdf:authoritativeLabel>Agriculture</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Agent rdf:about="http://example.org/11292563agent18">
+      <bf:label>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</bf:label>
+      <bf:authorizedAccessPoint>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/11292563title20">
+      <bf:label>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:label>
+      <bf:titleValue>Uitgaven van de Stichting "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11292563title21">
+      <bf:titleType>cover</bf:titleType>
+      <bf:label>Uitgaven "Natuurwetenschappelijke Studiedkring voor Suriname en Curaçao"</bf:label>
+      <bf:titleValue>Uitgaven "Natuurwetenschappelijke Studiedkring voor Suriname en Curaçao"</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/subseries/11292563.ttl
+++ b/spec/fixtures/loc/m2b-properties/subseries/11292563.ttl
@@ -1,0 +1,165 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11292563annotation16> a bf:Annotation;
+   bf:annotates <http://example.org/11292563>;
+   bf:changeDate "2012-12-13T08:45";
+   bf:derivedFrom <http://example.org/11292563.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/wau>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/hebis>,
+     <http://id.loc.gov/vocabulary/organizations/gbvcp>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/mh>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11292563helditem41> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11292563instance17>;
+   bf:label "QH7 .N2842";
+   bf:shelfMarkLcc "QH7 .N2842" .
+
+<http://example.org/11292563agent18> a bf:Agent;
+   bf:authorizedAccessPoint "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."
+   ];
+   bf:label "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao." .
+
+<http://example.org/11292563instance17> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "25 cm.";
+   bf:extent "5 v. :";
+   bf:frequencyNote "Irregular";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11292563>;
+   bf:instanceTitle <http://example.org/11292563title20>;
+   bf:languageNote "Dutch and English.";
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sf 85004161"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:nban [
+     a bf:Identifier;
+     bf:identifierAssigner "DE-600";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "990791--9"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "DE-101";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "015286398"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "DE-600";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "9907919"
+   ];
+   bf:nbn [
+     a bf:Identifier;
+     bf:identifierAssigner "dnb";
+     bf:identifierScheme loc_ids:nbn;
+     bf:identifierValue "015286398"
+   ];
+   bf:note "Title varies slightly.";
+   bf:providerStatement "Utrecht : De Studiekring, 1946-1948.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1946-1948";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "De Studiekring"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Utrecht "
+     ]
+   ];
+   bf:serialFirstIssue "No. 1";
+   bf:serialLastIssue "no. 5.";
+   bf:systemNumber <http://www.worldcat.org/oclc/05909923>;
+   bf:titleStatement "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"";
+   bf:titleVariation <http://example.org/11292563title21> .
+
+<http://example.org/11292563organization6> a bf:Organization;
+   bf:authorizedAccessPoint "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao."
+   ];
+   bf:label "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao." .
+
+<http://example.org/11292563title20> a bf:Title;
+   bf:label "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"";
+   bf:titleValue "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"" .
+
+<http://example.org/11292563title21> a bf:Title;
+   bf:label "Uitgaven \"Natuurwetenschappelijke Studiedkring voor Suriname en Curaçao\"";
+   bf:titleType "cover";
+   bf:titleValue "Uitgaven \"Natuurwetenschappelijke Studiedkring voor Suriname en Curaçao\"" .
+
+<http://example.org/11292563title5> a bf:Title;
+   bf:label "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"";
+   bf:titleValue "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"" .
+
+<http://example.org/11292563topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Agriculture";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:Topic;
+     mads:authoritativeLabel "Agriculture";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Agriculture" .
+
+<http://example.org/11292563topic9> a bf:Topic;
+   bf:authorizedAccessPoint "Natural history";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:Topic;
+     mads:authoritativeLabel "Natural history";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Natural history" .
+
+<http://example.org/11292563work12> a bf:Work;
+   bf:authorizedAccessPoint "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en de Nederlandse Antillen\"";
+   bf:issn <urn:issn:0300-5534>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/54027432>;
+   bf:systemNumber <http://www.worldcat.org/oclc/1388681>;
+   bf:title "Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en de Nederlandse Antillen\"" .
+
+<http://example.org/11292563work13> a bf:Work;
+   bf:authorizedAccessPoint "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao. Jaarboek - Natuurwetenschappelijke Studiekring voor Suriname en Curaçao";
+   bf:contributor <http://example.org/11292563agent18>;
+   bf:systemNumber <http://www.worldcat.org/oclc/5981961>;
+   bf:title "Jaarboek - Natuurwetenschappelijke Studiekring voor Suriname en Curaçao" .
+
+<http://example.org/11292563work14> a bf:Work;
+   bf:authorizedAccessPoint "Studies on the fauna of Curaçao, Aruba, Bonaire and the Venezuelan Islands";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/73615350>;
+   bf:systemNumber <http://www.worldcat.org/oclc/2607544>;
+   bf:title "Studies on the fauna of Curaçao, Aruba, Bonaire and the Venezuelan Islands" .
+
+<http://example.org/11292563> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Natuurwetenschappelijke Studiekring voor Suriname en Curaçao. Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"Uitgaven van de Stichting \"Natuurwetenschappelijke Studiekring voor Suriname en Curaçao.\"",
+     "natuurwetenschappelijkestudiekringvoorsurinameencuraçaouitgavenvandestichtingnatuurwetenschappelijkestudiekringvoorsurinameencuraçaodutworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/QH7>;
+   bf:continuedBy <http://example.org/11292563work12>;
+   bf:contributor <http://example.org/11292563organization6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/dut>,
+     <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/11292563topic9>,
+     <http://example.org/11292563topic10>;
+   bf:subseries <http://example.org/11292563work13>,
+     <http://example.org/11292563work14>;
+   bf:workTitle <http://example.org/11292563title5> .

--- a/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.marcxml
+++ b/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02684cas a2200565 a 4500</leader>
   <controlfield tag="001">11374173</controlfield>
   <controlfield tag="005">20130327080106.0</controlfield>
@@ -180,4 +180,4 @@
     <subfield code="b">B/L</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11374173</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.rdfxml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11374173">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Acquisition, Tracking, and Pointing. Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.Acquisition, Tracking, and Pointing :papers</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11374173title5"/>
+      <bf:creator rdf:resource="http://example.org/11374173meeting6"/>
+      <bf:contributor rdf:resource="http://example.org/11374173organization7"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>1050-5784</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11374173topic10"/>
+      <bf:subject rdf:resource="http://example.org/11374173topic11"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/TK6592.O6"/>
+      <bf:classification rdf:resource="http://example.org/11374173classification13"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>1050-5784</bf:identifierValue>
+            <bf:identifierAssigner>0</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:series rdf:resource="http://example.org/11374173work15"/>
+      <bf:subseriesOf rdf:resource="http://example.org/11374173work16"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">acquisitiontrackingandpointingsocietyofphotoopticalinstrumentationengineersacquisitiontrackingandpointingpapersengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11374173work15">
+      <bf:title>Proceedings of SPIE--the International Society for Optical Engineering</bf:title>
+      <bf:authorizedAccessPoint>Proceedings of SPIE--the International Society for Optical Engineering</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11374173work16">
+      <bf:title>Proceedings of SPIE--the International Society for Optical Engineering</bf:title>
+      <bf:authorizedAccessPoint>Proceedings of SPIE--the International Society for Optical Engineering</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0277-786X"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11374173instance19">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11374173title22"/>
+      <bf:keyTitle rdf:resource="http://example.org/11374173title23"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11374173title24"/>
+      <bf:titleVariation rdf:resource="http://example.org/11374173title25"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>International Society for Optical Engineering</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Bellingham, Wash., USA </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>[1986]-c2006</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11374173instance28"/>
+      <bf:extent>18 v. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>Acquisition, Tracking, and Pointing : papers</bf:titleStatement>
+      <bf:providerStatement>Bellingham, Wash., USA : International Society for Optical Engineering, 1986-c2006.</bf:providerStatement>
+      <bf:frequencyNote>Irregular</bf:frequencyNote>
+      <bf:note>Sponsored in cooperation with various organizations.</bf:note>
+      <bf:note>Title varies slightly.</bf:note>
+      <bf:note>Beginning with the 2007 conference, issues are cataloged separately.</bf:note>
+      <bf:note>Vol. for 1986 lacks numeric designation, but constitutes v. 1.</bf:note>
+      <bf:note>First issue lacks numeric designation.</bf:note>
+      <bf:note>Beginning with &lt;1998&gt; issued also online via the World Wide Web; earlier vols. may have tables of contents and abstracts freely available.</bf:note>
+      <bf:note>Latest issue consulted: 7 (15/16 Apr. 1993).</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>90649125</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+            <bf:identifierValue>sn 90030029</bf:identifierValue>
+            <bf:identifierStatus>canceled/invalid</bf:identifierStatus>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>1050-5784</bf:identifierValue>
+            <bf:identifierAssigner>0</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/21130732"/>
+      <bf:stockNumber>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/stockNumber"/>
+            <bf:identifierAssigner>SPIE, P.O. Box 10, Bellingham, WA 98227-0010</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:stockNumber>
+      <bf:serialFirstIssue>3/4 Apr. 1986</bf:serialFirstIssue>
+      <bf:serialLastIssue>20 (2006).</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11374173"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11374173instance28">
+      <bf:title>Acquisition, Tracking, and Pointing</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/763098336"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11374173instance20">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Electronic"/>
+      <bf:label>Electronic Resource</bf:label>
+      <bf:uri rdf:resource="http://spiedl.aip.org/browse/vol_title.jsp?scode=A"/>
+      <bf:instanceOf rdf:resource="http://example.org/11374173"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11374173annotation18">
+      <bf:derivedFrom rdf:resource="http://example.org/11374173.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/mcm"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nsdp"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nic"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/miu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/wau"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mcm"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mcm"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-03-27T08:01</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11374173"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11374173helditem51">
+      <bf:label>TK6592.O6 A288a</bf:label>
+      <bf:shelfMarkLcc>TK6592.O6 A288a</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11374173instance19"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11374173title5">
+      <bf:label>Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.</bf:label>
+      <bf:titleValue>Acquisition, Tracking, and Pointing :</bf:titleValue>
+      <bf:subtitle>papers </bf:subtitle>
+   </bf:Title>
+   <bf:Meeting rdf:about="http://example.org/11374173meeting6">
+      <bf:label>Acquisition, Tracking, and Pointing.</bf:label>
+      <bf:authorizedAccessPoint>Acquisition, Tracking, and Pointing.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Acquisition, Tracking, and Pointing.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Meeting>
+   <bf:Organization rdf:about="http://example.org/11374173organization7">
+      <bf:label>Society of Photo-optical Instrumentation Engineers.</bf:label>
+      <bf:authorizedAccessPoint>Society of Photo-optical Instrumentation Engineers.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Society of Photo-optical Instrumentation Engineers.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11374173topic10">
+      <bf:authorizedAccessPoint>Optical radar--Congresses</bf:authorizedAccessPoint>
+      <bf:label>Optical radar--Congresses</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Optical radar--Congresses</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Optical radar</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Optical radar</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Congresses</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Congresses.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11374173topic11">
+      <bf:authorizedAccessPoint>Optical detectors--Congresses</bf:authorizedAccessPoint>
+      <bf:label>Optical detectors--Congresses</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Optical detectors--Congresses</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Optical detectors</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Optical detectors</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Congresses</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Congresses.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11374173classification13">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>621.3848</bf:classificationNumber>
+      <bf:label>621.3848</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>20</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/11374173title22">
+      <bf:label>Acquis. Track. Pointing</bf:label>
+      <bf:titleValue>Acquis. Track. Pointing</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11374173title23">
+      <bf:label>Acquisition, Tracking, and Pointing</bf:label>
+      <bf:titleValue>Acquisition, Tracking, and Pointing</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11374173title24">
+      <bf:label>Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.</bf:label>
+      <bf:titleValue>Acquisition, Tracking, and Pointing :</bf:titleValue>
+      <bf:subtitle>papers </bf:subtitle>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11374173title25">
+      <bf:titleType>portion</bf:titleType>
+      <bf:label>Acquisitions, Tracking, and Pointing</bf:label>
+      <bf:titleValue>Acquisitions, Tracking, and Pointing</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.ttl
+++ b/spec/fixtures/loc/m2b-properties/subseriesOf/11374173.ttl
@@ -1,0 +1,233 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11374173annotation18> a bf:Annotation;
+   bf:annotates <http://example.org/11374173>;
+   bf:changeDate "2013-03-27T08:01";
+   bf:derivedFrom <http://example.org/11374173.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nsdp>,
+     <http://id.loc.gov/vocabulary/organizations/nic>,
+     <http://id.loc.gov/vocabulary/organizations/miu>,
+     <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/wau>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/mcm>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/mcm>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11374173helditem51> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11374173instance19>;
+   bf:label "TK6592.O6 A288a";
+   bf:shelfMarkLcc "TK6592.O6 A288a" .
+
+<http://example.org/11374173instance20> a bf:Instance,
+     bf:Electronic;
+   bf:instanceOf <http://example.org/11374173>;
+   bf:label "Electronic Resource";
+   bf:uri <http://spiedl.aip.org/browse/vol_title.jsp?scode=A> .
+
+<http://example.org/11374173classification13> a bf:Classification;
+   bf:classificationEdition "full",
+     "20";
+   bf:classificationNumber "621.3848";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "621.3848" .
+
+<http://example.org/11374173instance19> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11374173title22>;
+   bf:dimensions "28 cm.";
+   bf:extent "18 v. :";
+   bf:frequencyNote "Irregular";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11374173>;
+   bf:instanceTitle <http://example.org/11374173title24>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "0";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "1050-5784"
+   ];
+   bf:keyTitle <http://example.org/11374173title23>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "90649125"
+   ],  [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierStatus "canceled/invalid";
+     bf:identifierValue "sn 90030029"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Sponsored in cooperation with various organizations.",
+     "Title varies slightly.",
+     "Beginning with the 2007 conference, issues are cataloged separately.",
+     "Vol. for 1986 lacks numeric designation, but constitutes v. 1.",
+     "First issue lacks numeric designation.",
+     "Beginning with <1998> issued also online via the World Wide Web; earlier vols. may have tables of contents and abstracts freely available.",
+     "Latest issue consulted: 7 (15/16 Apr. 1993).",
+     "SERBIB/SERLOC merged record";
+   bf:otherPhysicalFormat <http://example.org/11374173instance28>;
+   bf:providerStatement "Bellingham, Wash., USA : International Society for Optical Engineering, 1986-c2006.";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "[1986]-c2006";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "International Society for Optical Engineering"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Bellingham, Wash., USA "
+     ]
+   ];
+   bf:serialFirstIssue "3/4 Apr. 1986";
+   bf:serialLastIssue "20 (2006).";
+   bf:stockNumber [
+     a bf:Identifier;
+     bf:identifierAssigner "SPIE, P.O. Box 10, Bellingham, WA 98227-0010";
+     bf:identifierScheme loc_ids:stockNumber
+   ];
+   bf:systemNumber <http://www.worldcat.org/oclc/21130732>;
+   bf:titleStatement "Acquisition, Tracking, and Pointing : papers";
+   bf:titleVariation <http://example.org/11374173title25> .
+
+<http://example.org/11374173instance28> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/763098336>;
+   bf:title "Acquisition, Tracking, and Pointing" .
+
+<http://example.org/11374173meeting6> a bf:Meeting;
+   bf:authorizedAccessPoint "Acquisition, Tracking, and Pointing.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Acquisition, Tracking, and Pointing."
+   ];
+   bf:label "Acquisition, Tracking, and Pointing." .
+
+<http://example.org/11374173organization7> a bf:Organization;
+   bf:authorizedAccessPoint "Society of Photo-optical Instrumentation Engineers.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Society of Photo-optical Instrumentation Engineers."
+   ];
+   bf:label "Society of Photo-optical Instrumentation Engineers." .
+
+<http://example.org/11374173title22> a bf:Title;
+   bf:label "Acquis. Track. Pointing";
+   bf:titleValue "Acquis. Track. Pointing" .
+
+<http://example.org/11374173title23> a bf:Title;
+   bf:label "Acquisition, Tracking, and Pointing";
+   bf:titleValue "Acquisition, Tracking, and Pointing" .
+
+<http://example.org/11374173title24> a bf:Title;
+   bf:label "Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.";
+   bf:subtitle "papers ";
+   bf:titleValue "Acquisition, Tracking, and Pointing :" .
+
+<http://example.org/11374173title25> a bf:Title;
+   bf:label "Acquisitions, Tracking, and Pointing";
+   bf:titleType "portion";
+   bf:titleValue "Acquisitions, Tracking, and Pointing" .
+
+<http://example.org/11374173title5> a bf:Title;
+   bf:label "Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.";
+   bf:subtitle "papers ";
+   bf:titleValue "Acquisition, Tracking, and Pointing :" .
+
+<http://example.org/11374173topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Optical radar--Congresses";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Optical radar--Congresses";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Optical radar";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Optical radar"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Congresses";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Congresses."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Optical radar--Congresses" .
+
+<http://example.org/11374173topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Optical detectors--Congresses";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Optical detectors--Congresses";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Optical detectors";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Optical detectors"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Congresses";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Congresses."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Optical detectors--Congresses" .
+
+<http://example.org/11374173work15> a bf:Work;
+   bf:authorizedAccessPoint "Proceedings of SPIE--the International Society for Optical Engineering";
+   bf:title "Proceedings of SPIE--the International Society for Optical Engineering" .
+
+<http://example.org/11374173work16> a bf:Work;
+   bf:authorizedAccessPoint "Proceedings of SPIE--the International Society for Optical Engineering";
+   bf:issn <urn:issn:0277-786X>;
+   bf:title "Proceedings of SPIE--the International Society for Optical Engineering" .
+
+<http://example.org/11374173> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Acquisition, Tracking, and Pointing. Acquisition, Tracking, and Pointing : [papers] / sponsored by SPIE--the International Society for Optical Engineering.Acquisition, Tracking, and Pointing :papers",
+     "acquisitiontrackingandpointingsocietyofphotoopticalinstrumentationengineersacquisitiontrackingandpointingpapersengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11374173classification13>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/TK6592.O6>;
+   bf:contributor <http://example.org/11374173organization7>;
+   bf:creator <http://example.org/11374173meeting6>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "1050-5784"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "0";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "1050-5784"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:series <http://example.org/11374173work15>;
+   bf:subject <http://example.org/11374173topic10>,
+     <http://example.org/11374173topic11>;
+   bf:subseriesOf <http://example.org/11374173work16>;
+   bf:workTitle <http://example.org/11374173title5> .

--- a/spec/fixtures/loc/m2b-properties/subtitle/12035509.marcxml
+++ b/spec/fixtures/loc/m2b-properties/subtitle/12035509.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02847cam a2200493 a 4500</leader>
   <controlfield tag="001">12035509</controlfield>
   <controlfield tag="005">20110119132227.0</controlfield>
@@ -145,4 +145,4 @@
     <subfield code="a">collpull</subfield>
     <subfield code="e">ammem</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12035509</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/summary/16684455.marcxml
+++ b/spec/fixtures/loc/m2b-properties/summary/16684455.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01532cam a2200313 a 4500</leader>
   <controlfield tag="001">16684455</controlfield>
   <controlfield tag="005">20120622113842.0</controlfield>
@@ -103,4 +103,4 @@
     <subfield code="x">History</subfield>
     <subfield code="y">13th century.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16684455</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/summaryOf/17001357.marcxml
+++ b/spec/fixtures/loc/m2b-properties/summaryOf/17001357.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00935cam a22002774a 4500</leader>
   <controlfield tag="001">17001357</controlfield>
   <controlfield tag="005">20120402162911.0</controlfield>
@@ -78,4 +78,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">ODE-ca</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17001357</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/supplement/17438799.marcxml
+++ b/spec/fixtures/loc/m2b-properties/supplement/17438799.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01652cam a22003857a 4500</leader>
   <controlfield tag="001">17438799</controlfield>
   <controlfield tag="005">20120927145211.0</controlfield>
@@ -127,4 +127,4 @@
     <subfield code="n">I-10207493</subfield>
     <subfield code="s">Coutts</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17438799</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/supplement/17438799.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/supplement/17438799.rdfxml
@@ -1,0 +1,382 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/17438799">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Hashemi, Mohammad, 1969- Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.Reel Canada :integrated skills through Canadian film</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/17438799title5"/>
+      <bf:creator rdf:resource="http://example.org/17438799person6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic8"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic9"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic10"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic11"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic12"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic13"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic14"/>
+      <bf:subject rdf:resource="http://example.org/17438799topic15"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-cn"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/PE1128"/>
+      <bf:classification rdf:resource="http://example.org/17438799classification18"/>
+      <bf:series rdf:resource="http://example.org/17438799work19"/>
+      <bf:supplement rdf:resource="http://example.org/17438799work20"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">hashemimohammad1969reelcanadaintegratedskillsthroughcanadianfilmengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/17438799work19">
+      <bf:title>Culture link ; no. 1</bf:title>
+      <bf:authorizedAccessPoint>Culture link ; no. 1</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/17438799work20">
+      <bf:title>Reel Canada workbook. Culture link Culture link ;</bf:title>
+      <bf:authorizedAccessPoint>Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012. Reel Canada workbook. Culture link Culture link ;</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/17438799agent24"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/17438799instance23">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/17438799title26"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/0195444426"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9780195444421"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Oxford University Press</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Don Mills, Ont. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:copyrightDate>c2012.</bf:copyrightDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>ix, 198 p. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. (some col.), maps ;</bf:illustrationNote>
+      <bf:titleStatement>Reel Canada : integrated skills through Canadian film</bf:titleStatement>
+      <bf:providerStatement>Don Mills, Ont. : Oxford University Press, c2012.</bf:providerStatement>
+      <bf:supplementaryContentNote>Includes bibliographical references.</bf:supplementaryContentNote>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2012451667</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/710886482"/>
+      <bf:instanceOf rdf:resource="http://example.org/17438799"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/17438799annotation22">
+      <bf:derivedFrom rdf:resource="http://example.org/17438799.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/nlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/cdx"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclco"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2012-09-27T14:52</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/17438799"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/17438799helditem40">
+      <bf:label>PE1128 .H4145 2012</bf:label>
+      <bf:shelfMarkLcc>PE1128 .H4145 2012</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/17438799instance23"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/17438799title5">
+      <bf:label>Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.</bf:label>
+      <bf:titleValue>Reel Canada :</bf:titleValue>
+      <bf:subtitle>integrated skills through Canadian film </bf:subtitle>
+   </bf:Title>
+   <bf:Person rdf:about="http://example.org/17438799person6">
+      <bf:label>Hashemi, Mohammad, 1969-</bf:label>
+      <bf:authorizedAccessPoint>Hashemi, Mohammad, 1969-</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hashemi, Mohammad, 1969-</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Topic rdf:about="http://example.org/17438799topic8">
+      <bf:authorizedAccessPoint>Readers--Motion pictures--Canada</bf:authorizedAccessPoint>
+      <bf:label>Readers--Motion pictures--Canada</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Readers--Motion pictures--Canada</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Readers</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Readers</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Motion pictures</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Motion pictures</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Canada</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Canada.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic9">
+      <bf:authorizedAccessPoint>Readers (Adult)</bf:authorizedAccessPoint>
+      <bf:label>Readers (Adult)</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Topic"/>
+            <madsrdf:authoritativeLabel>Readers (Adult)</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic10">
+      <bf:authorizedAccessPoint>English language--Problems, exercises, etc</bf:authorizedAccessPoint>
+      <bf:label>English language--Problems, exercises, etc</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>English language--Problems, exercises, etc</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>English language</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>English language</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Problems, exercises, etc</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Problems, exercises, etc.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic11">
+      <bf:authorizedAccessPoint>English language--Textbooks for second language learners</bf:authorizedAccessPoint>
+      <bf:label>English language--Textbooks for second language learners</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>English language--Textbooks for second language learners</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://www.collectionscanada.gc.ca/obj/900/f11/040004/canadian-subject-headings"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>English language</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>English language</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Textbooks for second language learners</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Textbooks for second language learners.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic12">
+      <bf:authorizedAccessPoint>Anglais (Langue)--Manuels pour allophones</bf:authorizedAccessPoint>
+      <bf:label>Anglais (Langue)--Manuels pour allophones</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Anglais (Langue)--Manuels pour allophones</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Anglais (Langue)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Anglais (Langue)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Manuels pour allophones</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Manuels pour allophones.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic13">
+      <bf:authorizedAccessPoint>Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada</bf:authorizedAccessPoint>
+      <bf:label>Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Anglais (Langue)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Anglais (Langue)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Lectures et morceaux choisis</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Lectures et morceaux choisis</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Cinéma</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Cinéma</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Canada</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Canada.</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic14">
+      <bf:authorizedAccessPoint>Anglais (Langue)--Lectures et morceaux choisis pour adultes</bf:authorizedAccessPoint>
+      <bf:label>Anglais (Langue)--Lectures et morceaux choisis pour adultes</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Anglais (Langue)--Lectures et morceaux choisis pour adultes</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Anglais (Langue)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Anglais (Langue)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Lectures et morceaux choisis pour adultes</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Lectures et morceaux choisis pour adultes.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/17438799topic15">
+      <bf:authorizedAccessPoint>Anglais (Langue)--Problèmes et exercices</bf:authorizedAccessPoint>
+      <bf:label>Anglais (Langue)--Problèmes et exercices</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Anglais (Langue)--Problèmes et exercices</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://rvm.example.org/rvm"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Anglais (Langue)</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Anglais (Langue)</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Problèmes et exercices</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Problèmes et exercices.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/17438799classification18">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>428.6/4</bf:classificationNumber>
+      <bf:label>428.6/4</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>23</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Agent rdf:about="http://example.org/17438799agent24">
+      <bf:label>Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012.</bf:label>
+      <bf:authorizedAccessPoint>Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/17438799title26">
+      <bf:label>Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.</bf:label>
+      <bf:titleValue>Reel Canada :</bf:titleValue>
+      <bf:subtitle>integrated skills through Canadian film </bf:subtitle>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/supplement/17438799.ttl
+++ b/spec/fixtures/loc/m2b-properties/supplement/17438799.ttl
@@ -1,0 +1,341 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/17438799annotation22> a bf:Annotation;
+   bf:annotates <http://example.org/17438799>;
+   bf:changeDate "2012-09-27T14:52";
+   bf:derivedFrom <http://example.org/17438799.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/lccopycat>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/cdx>,
+     <http://id.loc.gov/vocabulary/organizations/oclco>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/nlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/17438799helditem40> a bf:HeldItem;
+   bf:holdingFor <http://example.org/17438799instance23>;
+   bf:label "PE1128 .H4145 2012";
+   bf:shelfMarkLcc "PE1128 .H4145 2012" .
+
+<http://example.org/17438799agent24> a bf:Agent;
+   bf:authorizedAccessPoint "Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012."
+   ];
+   bf:label "Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012." .
+
+<http://example.org/17438799classification18> a bf:Classification;
+   bf:classificationEdition "full",
+     "23";
+   bf:classificationNumber "428.6/4";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "428.6/4" .
+
+<http://example.org/17438799instance23> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "28 cm.";
+   bf:extent "ix, 198 p. :";
+   bf:illustrationNote "ill. (some col.), maps ;";
+   bf:instanceOf <http://example.org/17438799>;
+   bf:instanceTitle <http://example.org/17438799title26>;
+   bf:isbn10 <http://isbn.example.org/0195444426>;
+   bf:isbn13 <http://isbn.example.org/9780195444421>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2012451667"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:providerStatement "Don Mills, Ont. : Oxford University Press, c2012.";
+   bf:publication [
+     a bf:Provider;
+     bf:copyrightDate "c2012.";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Oxford University Press"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Don Mills, Ont. "
+     ]
+   ];
+   bf:supplementaryContentNote "Includes bibliographical references.";
+   bf:systemNumber <http://www.worldcat.org/oclc/710886482>;
+   bf:titleStatement "Reel Canada : integrated skills through Canadian film" .
+
+<http://example.org/17438799person6> a bf:Person;
+   bf:authorizedAccessPoint "Hashemi, Mohammad, 1969-";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hashemi, Mohammad, 1969-"
+   ];
+   bf:label "Hashemi, Mohammad, 1969-" .
+
+<http://example.org/17438799title26> a bf:Title;
+   bf:label "Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.";
+   bf:subtitle "integrated skills through Canadian film ";
+   bf:titleValue "Reel Canada :" .
+
+<http://example.org/17438799title5> a bf:Title;
+   bf:label "Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.";
+   bf:subtitle "integrated skills through Canadian film ";
+   bf:titleValue "Reel Canada :" .
+
+<http://example.org/17438799topic10> a bf:Topic;
+   bf:authorizedAccessPoint "English language--Problems, exercises, etc";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "English language--Problems, exercises, etc";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "English language";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "English language"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Problems, exercises, etc";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Problems, exercises, etc."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "English language--Problems, exercises, etc" .
+
+<http://example.org/17438799topic11> a bf:Topic;
+   bf:authorizedAccessPoint "English language--Textbooks for second language learners";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "English language--Textbooks for second language learners";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "English language";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "English language"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Textbooks for second language learners";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Textbooks for second language learners."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://www.collectionscanada.gc.ca/obj/900/f11/040004/canadian-subject-headings>
+   ];
+   bf:label "English language--Textbooks for second language learners" .
+
+<http://example.org/17438799topic12> a bf:Topic;
+   bf:authorizedAccessPoint "Anglais (Langue)--Manuels pour allophones";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Anglais (Langue)--Manuels pour allophones";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Anglais (Langue)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Anglais (Langue)"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Manuels pour allophones";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Manuels pour allophones."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Anglais (Langue)--Manuels pour allophones" .
+
+<http://example.org/17438799topic13> a bf:Topic;
+   bf:authorizedAccessPoint "Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Anglais (Langue)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Anglais (Langue)"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Lectures et morceaux choisis";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Lectures et morceaux choisis"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Cinéma";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Cinéma"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Canada";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Canada."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Anglais (Langue)--Lectures et morceaux choisis--Cinéma--Canada" .
+
+<http://example.org/17438799topic14> a bf:Topic;
+   bf:authorizedAccessPoint "Anglais (Langue)--Lectures et morceaux choisis pour adultes";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Anglais (Langue)--Lectures et morceaux choisis pour adultes";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Anglais (Langue)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Anglais (Langue)"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Lectures et morceaux choisis pour adultes";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Lectures et morceaux choisis pour adultes."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Anglais (Langue)--Lectures et morceaux choisis pour adultes" .
+
+<http://example.org/17438799topic15> a bf:Topic;
+   bf:authorizedAccessPoint "Anglais (Langue)--Problèmes et exercices";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Anglais (Langue)--Problèmes et exercices";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Anglais (Langue)";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Anglais (Langue)"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Problèmes et exercices";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Problèmes et exercices."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://rvm.example.org/rvm>
+   ];
+   bf:label "Anglais (Langue)--Problèmes et exercices" .
+
+<http://example.org/17438799topic8> a bf:Topic;
+   bf:authorizedAccessPoint "Readers--Motion pictures--Canada";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Readers--Motion pictures--Canada";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Readers";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Readers"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Motion pictures";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Motion pictures"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Canada";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Canada."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Readers--Motion pictures--Canada" .
+
+<http://example.org/17438799topic9> a bf:Topic;
+   bf:authorizedAccessPoint "Readers (Adult)";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:Topic;
+     mads:authoritativeLabel "Readers (Adult)";
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Readers (Adult)" .
+
+<http://example.org/17438799work19> a bf:Work;
+   bf:authorizedAccessPoint "Culture link ; no. 1";
+   bf:title "Culture link ; no. 1" .
+
+<http://example.org/17438799work20> a bf:Work;
+   bf:authorizedAccessPoint "Payne, Beverley, 1950- Don Mills, Ont. : Oxford University Press, c2012. Reel Canada workbook. Culture link Culture link ;";
+   bf:contributor <http://example.org/17438799agent24>;
+   bf:title "Reel Canada workbook. Culture link Culture link ;" .
+
+<http://example.org/17438799> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Hashemi, Mohammad, 1969- Reel Canada : integrated skills through Canadian film / Mohammad Hashemi.Reel Canada :integrated skills through Canadian film",
+     "hashemimohammad1969reelcanadaintegratedskillsthroughcanadianfilmengworktext"@x-bf-hash;
+   bf:classification <http://example.org/17438799classification18>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/PE1128>;
+   bf:creator <http://example.org/17438799person6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:series <http://example.org/17438799work19>;
+   bf:subject <http://example.org/17438799topic8>,
+     <http://example.org/17438799topic9>,
+     <http://example.org/17438799topic10>,
+     <http://example.org/17438799topic11>,
+     <http://example.org/17438799topic12>,
+     <http://example.org/17438799topic13>,
+     <http://example.org/17438799topic14>,
+     <http://example.org/17438799topic15>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-cn>;
+   bf:supplement <http://example.org/17438799work20>;
+   bf:workTitle <http://example.org/17438799title5> .

--- a/spec/fixtures/loc/m2b-properties/supplementTo/13019979.marcxml
+++ b/spec/fixtures/loc/m2b-properties/supplementTo/13019979.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01793cas a2200409 a 4500</leader>
   <controlfield tag="001">13019979</controlfield>
   <controlfield tag="005">20130501082140.0</controlfield>
@@ -137,4 +137,4 @@
     <subfield code="e">db26 2004-05-05</subfield>
     <subfield code="g">db26 2004-05-05 to Ser</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13019979</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/supplementTo/13019979.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/supplementTo/13019979.rdfxml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/13019979">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Vital statistics supplement / State of Hawai'i, Department of Health.Vital statistics supplement</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/13019979title5"/>
+      <bf:creator rdf:resource="http://example.org/13019979jurisdiction6"/>
+      <bf:contributor rdf:resource="http://example.org/13019979jurisdiction7"/>
+      <bf:contentCategory rdf:resource="http://id.loc.gov/vocabulary/contentTypes/txt"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/13019979topic10"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us-hi"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/RA386"/>
+      <bf:continuesInPart rdf:resource="http://example.org/13019979work13"/>
+      <bf:supplementTo rdf:resource="http://example.org/13019979work14"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">hawaiidepartmentofhealthhawaiiofficeofhealthstatusmonitoringvitalstatisticssupplementengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13019979work13">
+      <bf:title>Annual report (1989). Statistical supplement</bf:title>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Annual report (1989). Statistical supplement</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn91034174"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/24280823"/>
+      <bf:contributor rdf:resource="http://example.org/13019979agent19"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/13019979work14">
+      <bf:title>Annual report (1984)</bf:title>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health. Annual report (1984)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/87647860"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/14368386"/>
+      <bf:contributor rdf:resource="http://example.org/13019979agent20"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/13019979instance17">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/13019979title20"/>
+      <bf:titleVariation rdf:resource="http://example.org/13019979title21"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Dept. of Health, Office of Health Status Monitoring</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Honolulu </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1994-</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/13019979instance24"/>
+      <bf:extent>volumes :</bf:extent>
+      <bf:dimensions>28 cm</bf:dimensions>
+      <bf:illustrationNote>illustrations ;</bf:illustrationNote>
+      <bf:titleStatement>Vital statistics supplement</bf:titleStatement>
+      <bf:providerStatement>Honolulu : Dept. of Health, Office of Health Status Monitoring, 1994-</bf:providerStatement>
+      <bf:frequencyNote>Biennial</bf:frequencyNote>
+      <bf:note>"This is the statistical supplement to the narrative report published in a separate volume."</bf:note>
+      <bf:note>Latest issue consulted: 1995.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sn 95039821</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/31820559"/>
+      <bf:mediaCategory rdf:resource="http://id.loc.gov/vocabulary/mediaTypes/n"/>
+      <bf:carrierCategory rdf:resource="http://id.loc.gov/vocabulary/carriers/nc"/>
+      <bf:serialFirstIssue>1991</bf:serialFirstIssue>
+      <bf:serialLastIssue>1992-</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/13019979"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/13019979instance24">
+      <bf:title>Vital statistics supplement</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/732920129"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/13019979annotation16">
+      <bf:derivedFrom rdf:resource="http://example.org/13019979.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/cu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/n"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-05-01T08:21</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/13019979"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/13019979helditem40">
+      <bf:label>RA386 .H37a</bf:label>
+      <bf:shelfMarkLcc>RA386 .H37a</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/13019979instance17"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/13019979title5">
+      <bf:label>Vital statistics supplement / State of Hawai'i, Department of Health.</bf:label>
+      <bf:titleValue>Vital statistics supplement</bf:titleValue>
+   </bf:Title>
+   <bf:Jurisdiction rdf:about="http://example.org/13019979jurisdiction6">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Jurisdiction rdf:about="http://example.org/13019979jurisdiction7">
+      <bf:label>Hawaii. Office of Health Status Monitoring.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Office of Health Status Monitoring.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Office of Health Status Monitoring.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Topic rdf:about="http://example.org/13019979topic10">
+      <bf:authorizedAccessPoint>Vital statistics--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Vital statistics--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Vital statistics--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Vital statistics</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Vital statistics</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Agent rdf:about="http://example.org/13019979agent19">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/13019979agent20">
+      <bf:label>Hawaii. Department of Health.</bf:label>
+      <bf:authorizedAccessPoint>Hawaii. Department of Health.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Hawaii. Department of Health.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/13019979title20">
+      <bf:label>Vital statistics supplement / State of Hawai'i, Department of Health.</bf:label>
+      <bf:titleValue>Vital statistics supplement</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/13019979title21">
+      <bf:titleType>cover</bf:titleType>
+      <bf:label>Biennial report for ... Vital statistics supplement 1991-1992</bf:label>
+      <bf:titleValue>Biennial report for ...</bf:titleValue>
+      <bf:partTitle>Vital statistics supplement</bf:partTitle>
+      <bf:titleVariationDate>1991-1992</bf:titleVariationDate>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/supplementTo/13019979.ttl
+++ b/spec/fixtures/loc/m2b-properties/supplementTo/13019979.ttl
@@ -1,0 +1,168 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/13019979annotation16> a bf:Annotation;
+   bf:annotates <http://example.org/13019979>;
+   bf:changeDate "2013-05-01T08:21";
+   bf:derivedFrom <http://example.org/13019979.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/n>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/cu>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/13019979helditem40> a bf:HeldItem;
+   bf:holdingFor <http://example.org/13019979instance17>;
+   bf:label "RA386 .H37a";
+   bf:shelfMarkLcc "RA386 .H37a" .
+
+<http://example.org/13019979agent19> a bf:Agent;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979agent20> a bf:Agent;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979instance17> a bf:Instance,
+     bf:Serial;
+   bf:carrierCategory <http://id.loc.gov/vocabulary/carriers/nc>;
+   bf:dimensions "28 cm";
+   bf:extent "volumes :";
+   bf:frequencyNote "Biennial";
+   bf:illustrationNote "illustrations ;";
+   bf:instanceOf <http://example.org/13019979>;
+   bf:instanceTitle <http://example.org/13019979title20>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sn 95039821"
+   ];
+   bf:mediaCategory <http://id.loc.gov/vocabulary/mediaTypes/n>;
+   bf:modeOfIssuance "serial";
+   bf:note "\"This is the statistical supplement to the narrative report published in a separate volume.\"",
+     "Latest issue consulted: 1995.";
+   bf:otherPhysicalFormat <http://example.org/13019979instance24>;
+   bf:providerStatement "Honolulu : Dept. of Health, Office of Health Status Monitoring, 1994-";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1994-";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Dept. of Health, Office of Health Status Monitoring"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Honolulu "
+     ]
+   ];
+   bf:serialFirstIssue "1991";
+   bf:serialLastIssue "1992-";
+   bf:systemNumber <http://www.worldcat.org/oclc/31820559>;
+   bf:titleStatement "Vital statistics supplement";
+   bf:titleVariation <http://example.org/13019979title21> .
+
+<http://example.org/13019979instance24> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/732920129>;
+   bf:title "Vital statistics supplement" .
+
+<http://example.org/13019979jurisdiction6> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Hawaii. Department of Health.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Department of Health."
+   ];
+   bf:label "Hawaii. Department of Health." .
+
+<http://example.org/13019979jurisdiction7> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "Hawaii. Office of Health Status Monitoring.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Hawaii. Office of Health Status Monitoring."
+   ];
+   bf:label "Hawaii. Office of Health Status Monitoring." .
+
+<http://example.org/13019979title20> a bf:Title;
+   bf:label "Vital statistics supplement / State of Hawai'i, Department of Health.";
+   bf:titleValue "Vital statistics supplement" .
+
+<http://example.org/13019979title21> a bf:Title;
+   bf:label "Biennial report for ... Vital statistics supplement 1991-1992";
+   bf:partTitle "Vital statistics supplement";
+   bf:titleType "cover";
+   bf:titleValue "Biennial report for ...";
+   bf:titleVariationDate "1991-1992" .
+
+<http://example.org/13019979title5> a bf:Title;
+   bf:label "Vital statistics supplement / State of Hawai'i, Department of Health.";
+   bf:titleValue "Vital statistics supplement" .
+
+<http://example.org/13019979topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Vital statistics--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Vital statistics--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Vital statistics";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Vital statistics"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Vital statistics--Periodicals" .
+
+<http://example.org/13019979work13> a bf:Work;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Annual report (1989). Statistical supplement";
+   bf:contributor <http://example.org/13019979agent19>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn91034174>;
+   bf:systemNumber <http://www.worldcat.org/oclc/24280823>;
+   bf:title "Annual report (1989). Statistical supplement" .
+
+<http://example.org/13019979work14> a bf:Work;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Annual report (1984)";
+   bf:contributor <http://example.org/13019979agent20>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/87647860>;
+   bf:systemNumber <http://www.worldcat.org/oclc/14368386>;
+   bf:title "Annual report (1984)" .
+
+<http://example.org/13019979> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Hawaii. Department of Health. Vital statistics supplement / State of Hawai'i, Department of Health.Vital statistics supplement",
+     "hawaiidepartmentofhealthhawaiiofficeofhealthstatusmonitoringvitalstatisticssupplementengworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/RA386>;
+   bf:contentCategory <http://id.loc.gov/vocabulary/contentTypes/txt>;
+   bf:continuesInPart <http://example.org/13019979work13>;
+   bf:contributor <http://example.org/13019979jurisdiction7>;
+   bf:creator <http://example.org/13019979jurisdiction6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/13019979topic10>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us-hi>;
+   bf:supplementTo <http://example.org/13019979work14>;
+   bf:workTitle <http://example.org/13019979title5> .

--- a/spec/fixtures/loc/m2b-properties/supplementaryContentNote/15875548.marcxml
+++ b/spec/fixtures/loc/m2b-properties/supplementaryContentNote/15875548.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01116cam a22002894a 4500</leader>
   <controlfield tag="001">15875548</controlfield>
   <controlfield tag="005">20150423131224.0</controlfield>
@@ -86,4 +86,4 @@
     <subfield code="y">20th century</subfield>
     <subfield code="x">History and criticism.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15875548</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/systemNumber/3556119.marcxml
+++ b/spec/fixtures/loc/m2b-properties/systemNumber/3556119.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01568nam a2200397 a 4500</leader>
   <controlfield tag="001">3556119</controlfield>
   <controlfield tag="005">19980212092839.1</controlfield>
@@ -125,4 +125,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">BOOKS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=3556119</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/tableOfContents/15367205.marcxml
+++ b/spec/fixtures/loc/m2b-properties/tableOfContents/15367205.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01355cam a22003134a 4500</leader>
   <controlfield tag="001">15367205</controlfield>
   <controlfield tag="005">20150129090636.0</controlfield>
@@ -96,4 +96,4 @@
     <subfield code="3">Publisher description</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1502/2008031024-d.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15367205</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/tableOfContentsFor/15367205.marcxml
+++ b/spec/fixtures/loc/m2b-properties/tableOfContentsFor/15367205.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01355cam a22003134a 4500</leader>
   <controlfield tag="001">15367205</controlfield>
   <controlfield tag="005">20150129090636.0</controlfield>
@@ -96,4 +96,4 @@
     <subfield code="3">Publisher description</subfield>
     <subfield code="u">http://www.loc.gov/catdir/enhancements/fy1502/2008031024-d.html</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15367205</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/temporalCoverageNote/14389913.marcxml
+++ b/spec/fixtures/loc/m2b-properties/temporalCoverageNote/14389913.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02051cam a22004217a 4500</leader>
   <controlfield tag="001">14389913</controlfield>
   <controlfield tag="005">20130531103624.0</controlfield>
@@ -129,4 +129,4 @@
   <datafield tag="856" ind1="4" ind2="1">
     <subfield code="u">http://www.whrp.org/Research/publications/Final%20Reports/WHRP%5F05-11%5FModulus%5Fto%5FTemp%5FRelations.pdf</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14389913</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/title/630296.marcxml
+++ b/spec/fixtures/loc/m2b-properties/title/630296.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00850nam a22002411i 4500</leader>
   <controlfield tag="001">630296</controlfield>
   <controlfield tag="005">19960801113358.3</controlfield>

--- a/spec/fixtures/loc/m2b-properties/titleAttribute/9719312.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleAttribute/9719312.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>00832cam a2200205u  4500</leader>
   <controlfield tag="001">9719312</controlfield>
   <controlfield tag="005">20121217142451.0</controlfield>
@@ -66,4 +66,4 @@
     <subfield code="t">Copy 1</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=9719312</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleQualifier/12800873.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleQualifier/12800873.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01794cas a2200433 a 4500</leader>
   <controlfield tag="001">12800873</controlfield>
   <controlfield tag="005">20130323160419.0</controlfield>
@@ -135,4 +135,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">eserial 200406</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12800873</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleSource/11140102.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleSource/11140102.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>04331cas a22009371  4500</leader>
   <controlfield tag="001">11140102</controlfield>
   <controlfield tag="005">20130826132502.0</controlfield>
@@ -378,4 +378,4 @@
     <subfield code="b">SER</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11140102</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleStatement/11158170.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleStatement/11158170.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>05201cas a2201021 a 4500</leader>
   <controlfield tag="001">11158170</controlfield>
   <controlfield tag="005">20130711075246.0</controlfield>
@@ -550,4 +550,4 @@
     <subfield code="b">call x7-5305</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11158170</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleStatement/12035509.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleStatement/12035509.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02847cam a2200493 a 4500</leader>
   <controlfield tag="001">12035509</controlfield>
   <controlfield tag="005">20110119132227.0</controlfield>
@@ -145,4 +145,4 @@
     <subfield code="a">collpull</subfield>
     <subfield code="e">ammem</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12035509</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleType/11497727.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleType/11497727.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02762cas a2200553 a 4500</leader>
   <controlfield tag="001">11497727</controlfield>
   <controlfield tag="005">20100417101726.0</controlfield>
@@ -176,4 +176,4 @@
     <subfield code="b">SER</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11497727</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleType/12863283.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleType/12863283.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01155ccm a22003254a 4500</leader>
   <controlfield tag="001">12863283</controlfield>
   <controlfield tag="005">20130410064101.0</controlfield>
@@ -95,4 +95,4 @@
   <datafield tag="985" ind1=" " ind2=" ">
     <subfield code="e">VENDOR LOAD</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12863283</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleValue/12035509.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleValue/12035509.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02847cam a2200493 a 4500</leader>
   <controlfield tag="001">12035509</controlfield>
   <controlfield tag="005">20110119132227.0</controlfield>
@@ -145,4 +145,4 @@
     <subfield code="a">collpull</subfield>
     <subfield code="e">ammem</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12035509</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleVariation/13781336.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleVariation/13781336.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02443cam a2200493 a 4500</leader>
   <controlfield tag="001">13781336</controlfield>
   <controlfield tag="005">20090928184310.0</controlfield>
@@ -147,4 +147,4 @@
     <subfield code="d">2004</subfield>
     <subfield code="s">94000511</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13781336</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/titleVariationDate/16482268.marcxml
+++ b/spec/fixtures/loc/m2b-properties/titleVariationDate/16482268.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01313cas a2200313 a 4500</leader>
   <controlfield tag="001">16482268</controlfield>
   <controlfield tag="005">20130215081229.0</controlfield>
@@ -88,4 +88,4 @@
     <subfield code="a">ce03 2010-09-29</subfield>
     <subfield code="i">ce03 2010-09-29</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16482268</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/translation/11500013.marcxml
+++ b/spec/fixtures/loc/m2b-properties/translation/11500013.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01393cas a2200385 a 4500</leader>
   <controlfield tag="001">11500013</controlfield>
   <controlfield tag="005">20130125075625.0</controlfield>
@@ -117,4 +117,4 @@
     <subfield code="b">AMED</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11500013</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/translation/11500013.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/translation/11500013.rdfxml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11500013">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Mekhon Meʾir (Israel) Be-ahavah uve-emunah.Be-ahavah uve-emunah</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11500013title5"/>
+      <bf:contributor rdf:resource="http://example.org/11500013organization6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/heb"/>
+      <bf:subject rdf:resource="http://example.org/11500013topic8"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/a-is"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/BM390"/>
+      <bf:translation rdf:resource="http://example.org/11500013work11"/>
+      <bf:translation rdf:resource="http://example.org/11500013work12"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">mekhonmeʾirisraelbeahavahuveemunahhebworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11500013work11">
+      <bf:title>Be-ahavah uve-emunah. English. Be-ahavah uve-emunah</bf:title>
+      <bf:authorizedAccessPoint>Be-ahavah uve-emunah. English. Be-ahavah uve-emunah</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2004222655"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/54847021"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11500013work12">
+      <bf:title>Be-ahavah uve-emunah</bf:title>
+      <bf:authorizedAccessPoint>Be-ahavah uve-emunah</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/2008222461"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/212626570"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11500013instance15">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11500013title18"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Mekhon Meʾir</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Yerushalayim </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>25-30 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>Be-ahavah uve-emunah.</bf:titleStatement>
+      <bf:providerStatement>Yerushalayim : Mekhon Meʾir</bf:providerStatement>
+      <bf:frequencyNote>Weekly</bf:frequencyNote>
+      <bf:note>Also available in English.</bf:note>
+      <bf:note>Description based on: Gil. 2 (8 be-Av 755 [4 be-Ogusṭ 1995]); title from caption.</bf:note>
+      <bf:note>Latest issue consulted: Gil. 128 (5 be-Ṭevet 758 [3 be-Yanuʾar 1998]).</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>98647021</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/38922280"/>
+      <bf:instanceOf rdf:resource="http://example.org/11500013"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11500013annotation14">
+      <bf:derivedFrom rdf:resource="http://example.org/11500013.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/clu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/clu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-01-25T07:56</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11500013"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11500013helditem34">
+      <bf:label>BM390 .B393</bf:label>
+      <bf:shelfMarkLcc>BM390 .B393</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11500013instance15"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11500013title5">
+      <bf:label>Be-ahavah uve-emunah.</bf:label>
+      <bf:titleValue>Be-ahavah uve-emunah</bf:titleValue>
+   </bf:Title>
+   <bf:Organization rdf:about="http://example.org/11500013organization6">
+      <bf:label>Mekhon Meʾir (Israel)</bf:label>
+      <bf:authorizedAccessPoint>Mekhon Meʾir (Israel)</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Mekhon Meʾir (Israel)</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11500013topic8">
+      <bf:authorizedAccessPoint>Orthodox Judaism--Israel--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Orthodox Judaism--Israel--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Orthodox Judaism--Israel--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Orthodox Judaism</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Orthodox Judaism</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Israel</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>Israel</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11500013title18">
+      <bf:label>Be-ahavah uve-emunah.</bf:label>
+      <bf:titleValue>Be-ahavah uve-emunah</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/translation/11500013.ttl
+++ b/spec/fixtures/loc/m2b-properties/translation/11500013.ttl
@@ -1,0 +1,132 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11500013annotation14> a bf:Annotation;
+   bf:annotates <http://example.org/11500013>;
+   bf:changeDate "2013-01-25T07:56";
+   bf:derivedFrom <http://example.org/11500013.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/clu>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11500013helditem34> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11500013instance15>;
+   bf:label "BM390 .B393";
+   bf:shelfMarkLcc "BM390 .B393" .
+
+<http://example.org/11500013instance15> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "25-30 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Weekly";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11500013>;
+   bf:instanceTitle <http://example.org/11500013title18>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "98647021"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Also available in English.",
+     "Description based on: Gil. 2 (8 be-Av 755 [4 be-Ogusṭ 1995]); title from caption.",
+     "Latest issue consulted: Gil. 128 (5 be-Ṭevet 758 [3 be-Yanuʾar 1998]).",
+     "SERBIB/SERLOC merged record";
+   bf:providerStatement "Yerushalayim : Mekhon Meʾir";
+   bf:publication [
+     a bf:Provider;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Mekhon Meʾir"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Yerushalayim "
+     ]
+   ];
+   bf:systemNumber <http://www.worldcat.org/oclc/38922280>;
+   bf:titleStatement "Be-ahavah uve-emunah." .
+
+<http://example.org/11500013organization6> a bf:Organization;
+   bf:authorizedAccessPoint "Mekhon Meʾir (Israel)";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Mekhon Meʾir (Israel)"
+   ];
+   bf:label "Mekhon Meʾir (Israel)" .
+
+<http://example.org/11500013title18> a bf:Title;
+   bf:label "Be-ahavah uve-emunah.";
+   bf:titleValue "Be-ahavah uve-emunah" .
+
+<http://example.org/11500013title5> a bf:Title;
+   bf:label "Be-ahavah uve-emunah.";
+   bf:titleValue "Be-ahavah uve-emunah" .
+
+<http://example.org/11500013topic8> a bf:Topic;
+   bf:authorizedAccessPoint "Orthodox Judaism--Israel--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Orthodox Judaism--Israel--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Orthodox Judaism";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Orthodox Judaism"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "Israel";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "Israel"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Orthodox Judaism--Israel--Periodicals" .
+
+<http://example.org/11500013work11> a bf:Work;
+   bf:authorizedAccessPoint "Be-ahavah uve-emunah. English. Be-ahavah uve-emunah";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2004222655>;
+   bf:systemNumber <http://www.worldcat.org/oclc/54847021>;
+   bf:title "Be-ahavah uve-emunah. English. Be-ahavah uve-emunah" .
+
+<http://example.org/11500013work12> a bf:Work;
+   bf:authorizedAccessPoint "Be-ahavah uve-emunah";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/2008222461>;
+   bf:systemNumber <http://www.worldcat.org/oclc/212626570>;
+   bf:title "Be-ahavah uve-emunah" .
+
+<http://example.org/11500013> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Mekhon Meʾir (Israel) Be-ahavah uve-emunah.Be-ahavah uve-emunah",
+     "mekhonmeʾirisraelbeahavahuveemunahhebworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/BM390>;
+   bf:contributor <http://example.org/11500013organization6>;
+   bf:language <http://id.loc.gov/vocabulary/languages/heb>;
+   bf:subject <http://example.org/11500013topic8>,
+     <http://id.loc.gov/vocabulary/geographicAreas/a-is>;
+   bf:translation <http://example.org/11500013work11>,
+     <http://example.org/11500013work12>;
+   bf:workTitle <http://example.org/11500013title5> .

--- a/spec/fixtures/loc/m2b-properties/translationOf/11333828.marcxml
+++ b/spec/fixtures/loc/m2b-properties/translationOf/11333828.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>05964cas a2200961 a 4500</leader>
   <controlfield tag="001">11333828</controlfield>
   <controlfield tag="005">20131115075153.0</controlfield>
@@ -479,4 +479,4 @@
     <subfield code="b">SER</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11333828</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/translationOf/11333828.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/translationOf/11333828.rdfxml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11333828">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>American Geological Institute. Doklady Akademii nauk SSSR. English</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Doklady Akademii nauk SSSR. English.</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/11333828title6"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:titleValue xml:lang="en-cyrl">Доклады Академии наук СССР.</bf:titleValue>
+      <bf:translationOf rdf:resource="http://example.org/11333828work9"/>
+      <bf:contributor rdf:resource="http://example.org/11333828organization10"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierValue>0012-494X</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:language rdf:resource="http://example.org/11333828language13"/>
+      <bf:subject rdf:resource="http://example.org/11333828topic14"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/QE1"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/511"/>
+      <bf:classification rdf:resource="http://example.org/11333828classification17"/>
+      <bf:classification rdf:resource="http://example.org/11333828classification18"/>
+      <bf:issnL>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issnL"/>
+            <bf:identifierValue>0012-494X</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issnL>
+      <bf:continues rdf:resource="http://example.org/11333828work20"/>
+      <bf:continuedBy rdf:resource="http://example.org/11333828work21"/>
+      <bf:translationOf rdf:resource="http://example.org/11333828work22"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">americangeologicalinstitute88001dokladyakademiinauksssrenglishengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11333828work20">
+      <bf:title>Doklady Akademii nauk SSSR. English. Doklady of the Academy of Sciences of the U.S.S.R. Earth sciences sections</bf:title>
+      <bf:authorizedAccessPoint>Doklady Akademii nauk SSSR. English. Doklady of the Academy of Sciences of the U.S.S.R. Earth sciences sections</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="en-cyrl">Доклады Академии наук СССР. English. Доклады of the Academy of Sciences of the U.S.S.R. Earth sciences sections</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:2152-6915"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/65032664"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/1478790"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11333828work21">
+      <bf:title>Doklady Akademii nauk SSSR. English. Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections</bf:title>
+      <bf:authorizedAccessPoint>Doklady Akademii nauk SSSR. English. Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="en-cyrl">Доклады Академии наук СССР. English. Transactions (Доклады) of the USSR Academy of Sciences. Earth science sections</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0891-5571"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/88644046"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/14962377"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11333828work22">
+      <bf:title>Doklady Akademii nauk SSSR</bf:title>
+      <bf:authorizedAccessPoint>Doklady Akademii nauk SSSR</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="en-cyrl">Доклады Академии наук СССР</bf:authorizedAccessPoint>
+      <bf:issn rdf:resource="urn:issn:0002-3264"/>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/49037331"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/1478791"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11333828work9">
+      <bf:title>Doklady Akademii nauk SSSR.</bf:title>
+      <madsrdf:authoritativeLabel>Doklady Akademii nauk SSSR.</madsrdf:authoritativeLabel>
+      <bf:authorizedAccessPoint>Doklady Akademii nauk SSSR.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/11333828agent14"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11333828instance25">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:abbreviatedTitle rdf:resource="http://example.org/11333828title28"/>
+      <bf:keyTitle rdf:resource="http://example.org/11333828title29"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11333828title30"/>
+      <bf:titleVariation rdf:resource="http://example.org/11333828title31"/>
+      <bf:titleVariation rdf:resource="http://example.org/11333828title32"/>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>American Geological Institute</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Falls Church, Va. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>[1974-c1985]</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11333828instance35"/>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11333828instance36"/>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>26 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>Doklady.</bf:titleStatement>
+      <bf:providerStatement>Falls Church, Va. : American Geological Institute, 1974-c1985</bf:providerStatement>
+      <bf:frequencyNote>Bimonthly</bf:frequencyNote>
+      <bf:note>Title from cover.</bf:note>
+      <bf:note>English translations of selections from the Russian title: Doklady Akademii nauk SSSR.</bf:note>
+      <bf:note xml:lang="en-cyrl">English translations of selections from the Russian title: Доклады Академии наук СССР.</bf:note>
+      <bf:note>Continued in 1985 by: Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections.</bf:note>
+      <bf:note xml:lang="en-cyrl">Continued in 1985 by: Transactions (Доклады) of the USSR Academy of Sciences. Earth science sections.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>87657050</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:nban>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/nban"/>
+            <bf:identifierValue>009180750</bf:identifierValue>
+            <bf:identifierAssigner>Uk</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:nban>
+      <bf:issn>
+         <bf:Identifier>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/issn"/>
+            <bf:identifierValue>0012-494X</bf:identifierValue>
+            <bf:identifierAssigner>1</bf:identifierAssigner>
+         </bf:Identifier>
+      </bf:issn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/15219136"/>
+      <bf:serialFirstIssue>Vol. 208 (Jan.-Feb. 1973)</bf:serialFirstIssue>
+      <bf:serialLastIssue>v. 279 (Nov.-Dec. 1984).</bf:serialLastIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11333828"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11333828instance35">
+      <bf:title>Doklady Akademii nauk SSSR. English</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/603594843"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11333828instance36">
+      <bf:title>Doklady Akademii nauk SSSR. English</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/614973114"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11333828annotation24">
+      <bf:derivedFrom rdf:resource="http://example.org/11333828.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mh"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dnal"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/inu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nst"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/miu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/inu"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ukmgb"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclco"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/inu"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-11-15T07:51</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11333828"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/11333828helditem56">
+      <bf:label>QE1 .A25183</bf:label>
+      <bf:shelfMarkLcc>QE1 .A25183</bf:shelfMarkLcc>
+      <bf:shelfMarkLcc>511 P444aee</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/11333828instance25"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/11333828title6">
+      <bf:titleValue>Doklady Akademii nauk SSSR.</bf:titleValue>
+      <bf:titleValue xml:lang="en-cyrl">Доклады Академии наук СССР.</bf:titleValue>
+   </bf:Title>
+   <bf:Agent rdf:about="http://example.org/11333828agent14">
+      <bf:label/>
+   </bf:Agent>
+   <bf:Organization rdf:about="http://example.org/11333828organization10">
+      <bf:label>American Geological Institute.</bf:label>
+      <bf:authorizedAccessPoint>American Geological Institute.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>American Geological Institute.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Language rdf:about="http://example.org/11333828language13">
+      <bf:resourcePart>original</bf:resourcePart>
+      <bf:languageOfPartUri rdf:resource="http://id.loc.gov/vocabulary/languages/rus"/>
+   </bf:Language>
+   <bf:Topic rdf:about="http://example.org/11333828topic14">
+      <bf:authorizedAccessPoint>Geology--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Geology--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Geology--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Geology</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Geology</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11333828classification17">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>550</bf:classificationNumber>
+      <bf:label>550</bf:label>
+      <bf:classificationEdition>abridged</bf:classificationEdition>
+      <bf:classificationEdition>14</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Classification rdf:about="http://example.org/11333828classification18">
+      <bf:classificationScheme rdf:resource="http://id.loc.gov/authorities/classSchemes/ddc"/>
+      <bf:classificationNumber>550/.5</bf:classificationNumber>
+      <bf:label>550/.5</bf:label>
+      <bf:classificationEdition>full</bf:classificationEdition>
+      <bf:classificationEdition>19</bf:classificationEdition>
+   </bf:Classification>
+   <bf:Title rdf:about="http://example.org/11333828title28">
+      <bf:label>Dokl., Earth sci. sect.</bf:label>
+      <bf:titleValue>Dokl., Earth sci. sect.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11333828title29">
+      <bf:label>Doklady. Earth science sections</bf:label>
+      <bf:titleValue>Doklady. Earth science sections</bf:titleValue>
+      <bf:titleValue xml:lang="en-cyrl">Доклады. Earth science sections</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11333828title30">
+      <bf:label>Doklady. Earth science sections.</bf:label>
+      <bf:titleValue>Doklady</bf:titleValue>
+      <bf:partTitle>Earth science sections.</bf:partTitle>
+      <bf:titleValue xml:lang="en-cyrl">Доклады. Earth science sections.</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11333828title31">
+      <bf:titleType>portion</bf:titleType>
+      <bf:label>Earth science sections</bf:label>
+      <bf:titleValue>Earth science sections</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/11333828title32">
+      <bf:titleType>spine</bf:titleType>
+      <bf:label>Doklady EES &lt;Nov.-Dec. 1983&gt;</bf:label>
+      <bf:titleValue>Doklady EES</bf:titleValue>
+      <bf:titleVariationDate>&lt;Nov.-Dec. 1983&gt;</bf:titleVariationDate>
+      <bf:titleValue xml:lang="en-cyrl">Доклады ЕЕС &lt;Nov.-Dec. 1983&gt;</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/translationOf/11333828.ttl
+++ b/spec/fixtures/loc/m2b-properties/translationOf/11333828.ttl
@@ -1,0 +1,242 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11333828annotation24> a bf:Annotation;
+   bf:annotates <http://example.org/11333828>;
+   bf:changeDate "2013-11-15T07:51";
+   bf:derivedFrom <http://example.org/11333828.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>,
+     <http://id.loc.gov/vocabulary/descriptionAuthentication/nsdp>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/nst>,
+     <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/mh>,
+     <http://id.loc.gov/vocabulary/organizations/dnal>,
+     <http://id.loc.gov/vocabulary/organizations/inu>,
+     <http://id.loc.gov/vocabulary/organizations/miu>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>,
+     <http://id.loc.gov/vocabulary/organizations/ukmgb>,
+     <http://id.loc.gov/vocabulary/organizations/oclco>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11333828helditem56> a bf:HeldItem;
+   bf:holdingFor <http://example.org/11333828instance25>;
+   bf:label "QE1 .A25183";
+   bf:shelfMarkLcc "QE1 .A25183",
+     "511 P444aee" .
+
+<http://example.org/11333828agent14> a bf:Agent;
+   bf:label "" .
+
+<http://example.org/11333828classification17> a bf:Classification;
+   bf:classificationEdition "abridged",
+     "14";
+   bf:classificationNumber "550";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "550" .
+
+<http://example.org/11333828classification18> a bf:Classification;
+   bf:classificationEdition "full",
+     "19";
+   bf:classificationNumber "550/.5";
+   bf:classificationScheme <http://id.loc.gov/authorities/classSchemes/ddc>;
+   bf:label "550/.5" .
+
+<http://example.org/11333828instance25> a bf:Instance,
+     bf:Serial;
+   bf:abbreviatedTitle <http://example.org/11333828title28>;
+   bf:dimensions "26 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Bimonthly";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11333828>;
+   bf:instanceTitle <http://example.org/11333828title30>;
+   bf:issn [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issn;
+     bf:identifierValue "0012-494X"
+   ];
+   bf:keyTitle <http://example.org/11333828title29>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "87657050"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:nban [
+     a bf:Identifier;
+     bf:identifierAssigner "Uk";
+     bf:identifierScheme loc_ids:nban;
+     bf:identifierValue "009180750"
+   ];
+   bf:note "Title from cover.",
+     "English translations of selections from the Russian title: Doklady Akademii nauk SSSR.",
+     "English translations of selections from the Russian title: Доклады Академии наук СССР."@en-cyrl,
+     "Continued in 1985 by: Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections.",
+     "Continued in 1985 by: Transactions (Доклады) of the USSR Academy of Sciences. Earth science sections."@en-cyrl,
+     "SERBIB/SERLOC merged record";
+   bf:otherPhysicalFormat <http://example.org/11333828instance35>,
+     <http://example.org/11333828instance36>;
+   bf:providerStatement "Falls Church, Va. : American Geological Institute, 1974-c1985";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "[1974-c1985]";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "American Geological Institute"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Falls Church, Va. "
+     ]
+   ];
+   bf:serialFirstIssue "Vol. 208 (Jan.-Feb. 1973)";
+   bf:serialLastIssue "v. 279 (Nov.-Dec. 1984).";
+   bf:systemNumber <http://www.worldcat.org/oclc/15219136>;
+   bf:titleStatement "Doklady.";
+   bf:titleVariation <http://example.org/11333828title31>,
+     <http://example.org/11333828title32> .
+
+<http://example.org/11333828instance35> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/603594843>;
+   bf:title "Doklady Akademii nauk SSSR. English" .
+
+<http://example.org/11333828instance36> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/614973114>;
+   bf:title "Doklady Akademii nauk SSSR. English" .
+
+<http://example.org/11333828language13> a bf:Language;
+   bf:languageOfPartUri <http://id.loc.gov/vocabulary/languages/rus>;
+   bf:resourcePart "original" .
+
+<http://example.org/11333828organization10> a bf:Organization;
+   bf:authorizedAccessPoint "American Geological Institute.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "American Geological Institute."
+   ];
+   bf:label "American Geological Institute." .
+
+<http://example.org/11333828title28> a bf:Title;
+   bf:label "Dokl., Earth sci. sect.";
+   bf:titleValue "Dokl., Earth sci. sect." .
+
+<http://example.org/11333828title29> a bf:Title;
+   bf:label "Doklady. Earth science sections";
+   bf:titleValue "Doklady. Earth science sections",
+     "Доклады. Earth science sections"@en-cyrl .
+
+<http://example.org/11333828title30> a bf:Title;
+   bf:label "Doklady. Earth science sections.";
+   bf:partTitle "Earth science sections.";
+   bf:titleValue "Doklady",
+     "Доклады. Earth science sections."@en-cyrl .
+
+<http://example.org/11333828title31> a bf:Title;
+   bf:label "Earth science sections";
+   bf:titleType "portion";
+   bf:titleValue "Earth science sections" .
+
+<http://example.org/11333828title32> a bf:Title;
+   bf:label "Doklady EES <Nov.-Dec. 1983>";
+   bf:titleType "spine";
+   bf:titleValue "Doklady EES",
+     "Доклады ЕЕС <Nov.-Dec. 1983>"@en-cyrl;
+   bf:titleVariationDate "<Nov.-Dec. 1983>" .
+
+<http://example.org/11333828title6> a bf:Title;
+   bf:titleValue "Doklady Akademii nauk SSSR.",
+     "Доклады Академии наук СССР."@en-cyrl .
+
+<http://example.org/11333828topic14> a bf:Topic;
+   bf:authorizedAccessPoint "Geology--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Geology--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Geology";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Geology"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Geology--Periodicals" .
+
+<http://example.org/11333828work20> a bf:Work;
+   bf:authorizedAccessPoint "Doklady Akademii nauk SSSR. English. Doklady of the Academy of Sciences of the U.S.S.R. Earth sciences sections",
+     "Доклады Академии наук СССР. English. Доклады of the Academy of Sciences of the U.S.S.R. Earth sciences sections"@en-cyrl;
+   bf:issn <urn:issn:2152-6915>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/65032664>;
+   bf:systemNumber <http://www.worldcat.org/oclc/1478790>;
+   bf:title "Doklady Akademii nauk SSSR. English. Doklady of the Academy of Sciences of the U.S.S.R. Earth sciences sections" .
+
+<http://example.org/11333828work21> a bf:Work;
+   bf:authorizedAccessPoint "Doklady Akademii nauk SSSR. English. Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections",
+     "Доклады Академии наук СССР. English. Transactions (Доклады) of the USSR Academy of Sciences. Earth science sections"@en-cyrl;
+   bf:issn <urn:issn:0891-5571>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/88644046>;
+   bf:systemNumber <http://www.worldcat.org/oclc/14962377>;
+   bf:title "Doklady Akademii nauk SSSR. English. Transactions (Doklady) of the USSR Academy of Sciences. Earth science sections" .
+
+<http://example.org/11333828work22> a bf:Work;
+   bf:authorizedAccessPoint "Doklady Akademii nauk SSSR",
+     "Доклады Академии наук СССР"@en-cyrl;
+   bf:issn <urn:issn:0002-3264>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/49037331>;
+   bf:systemNumber <http://www.worldcat.org/oclc/1478791>;
+   bf:title "Doklady Akademii nauk SSSR" .
+
+<http://example.org/11333828work9> a bf:Work;
+   bf:authorizedAccessPoint "Doklady Akademii nauk SSSR.";
+   bf:contributor <http://example.org/11333828agent14>;
+   bf:title "Doklady Akademii nauk SSSR.";
+   mads:authoritativeLabel "Doklady Akademii nauk SSSR." .
+
+<http://example.org/11333828> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "American Geological Institute. Doklady Akademii nauk SSSR. English",
+     "americangeologicalinstitute88001dokladyakademiinauksssrenglishengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11333828classification17>,
+     <http://example.org/11333828classification18>;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/QE1>,
+     <http://id.loc.gov/authorities/classification/511>;
+   bf:continuedBy <http://example.org/11333828work21>;
+   bf:continues <http://example.org/11333828work20>;
+   bf:contributor <http://example.org/11333828organization10>;
+   bf:issnL [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0012-494X"
+   ],  [
+     a bf:Identifier;
+     bf:identifierAssigner "1";
+     bf:identifierScheme loc_ids:issnL;
+     bf:identifierValue "0012-494X"
+   ];
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>,
+     <http://example.org/11333828language13>;
+   bf:subject <http://example.org/11333828topic14>;
+   bf:titleValue "Доклады Академии наук СССР."@en-cyrl;
+   bf:translationOf <http://example.org/11333828work9>,
+     <http://example.org/11333828work22>;
+   bf:workTitle <http://example.org/11333828title6>;
+   mads:authoritativeLabel "Doklady Akademii nauk SSSR. English." .

--- a/spec/fixtures/loc/m2b-properties/translationOf/14507819.marcxml
+++ b/spec/fixtures/loc/m2b-properties/translationOf/14507819.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01514cam a2200337 a 4500</leader>
   <controlfield tag="001">14507819</controlfield>
   <controlfield tag="005">20130531115630.0</controlfield>
@@ -115,4 +115,4 @@
     <subfield code="6">730-05/(2/r</subfield>
     <subfield code="a">&#x5EA;&#x5DB;&#x5DC;&#x5EA; &#x5D0;&#x5D1;&#x5E8;&#x5D4;&#x5DD;.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=14507819</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/translationOf/14507819.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/translationOf/14507819.rdfxml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/14507819">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>Bible. Esther. Hebew. 2006</bf:authorizedAccessPoint>
+      <madsrdf:authoritativeLabel>Bible. Esther. Hebew. 2006.</madsrdf:authoritativeLabel>
+      <bf:workTitle rdf:resource="http://example.org/14507819title6"/>
+      <bf:language rdf:resource="http://example.org/14507819language7"/>
+      <bf:translationOf rdf:resource="http://example.org/14507819work8"/>
+      <bf:originDate>2006.</bf:originDate>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/heb"/>
+      <bf:classificationLcc rdf:resource="http://id.loc.gov/authorities/classification/BS1372"/>
+      <bf:hasPart rdf:resource="http://example.org/14507819work12"/>
+      <bf:hasPart rdf:resource="http://example.org/14507819work13"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">kormanabraham19172001bibleestherhebew2006hebworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14507819work12">
+      <bf:title>Tekhelet Avraham.</bf:title>
+      <bf:authorizedAccessPoint>Tekhelet Avraham.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="he-hebr">תכלת אברהם.</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14507819work13">
+      <bf:title>Tekhelet Avraham.</bf:title>
+      <bf:authorizedAccessPoint>Korman, Abraham, 1917-2001. Tekhelet Avraham.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="he-hebr">קורמן, אברהם. תכלת אברהם.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/14507819person18"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/14507819work8">
+      <bf:title>Bible. 2006.</bf:title>
+      <madsrdf:authoritativeLabel>Bible. 2006.</madsrdf:authoritativeLabel>
+      <bf:authorizedAccessPoint>Bible. 2006.</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/14507819agent13"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/14507819instance16">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Monograph"/>
+      <bf:instanceTitle rdf:resource="http://example.org/14507819title19"/>
+      <bf:titleVariation rdf:resource="http://example.org/14507819title20"/>
+      <bf:isbn10 rdf:resource="http://isbn.example.org/9659048653"/>
+      <bf:isbn13 rdf:resource="http://isbn.example.org/9789659048656"/>
+      <bf:responsibilityStatement xml:lang="he-hebr">מאת קורמן אברהם.</bf:responsibilityStatement>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>Yorshe Ḳorman Avraham</bf:label>
+                  <bf:label xml:lang="he-hebr">יורשי קורמן אברהם</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Tel Aviv </bf:label>
+                  <bf:label xml:lang="he-hebr">תל אביב :</bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>[766 i.e. 2006]</bf:providerDate>
+            <bf:providerDate xml:lang="he-hebr">766 i.e. 2006</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:edition xml:lang="he-hebr">מהדורה מתוקנת ומורחבת.</bf:edition>
+      <bf:modeOfIssuance>single unit</bf:modeOfIssuance>
+      <bf:extent>58 p. :</bf:extent>
+      <bf:dimensions>23 cm.</bf:dimensions>
+      <bf:illustrationNote>ill.;</bf:illustrationNote>
+      <bf:titleStatement>Megilat Ester : ʻi. p. tekhelet Avraham</bf:titleStatement>
+      <bf:edition>Mahad. metuḳenet u-murḥevet.</bf:edition>
+      <bf:providerStatement>Tel Aviv : Yorshe Ḳorman Avraham, 766 i.e. 2006</bf:providerStatement>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>2006473232</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber>
+         <bf:Identifier>
+            <bf:identifierValue>(CStRLIN)DCLH06-B2388</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/systemNumber"/>
+         </bf:Identifier>
+      </bf:systemNumber>
+      <bf:instanceOf rdf:resource="http://example.org/14507819"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/14507819annotation15">
+      <bf:derivedFrom rdf:resource="http://example.org/14507819.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlcr"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-05-31T11:56</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/14507819"/>
+   </bf:Annotation>
+   <bf:HeldItem rdf:about="http://example.org/14507819helditem36">
+      <bf:label>BS1372 .K68 2006</bf:label>
+      <bf:shelfMarkLcc>BS1372 .K68 2006</bf:shelfMarkLcc>
+      <bf:holdingFor rdf:resource="http://example.org/14507819instance16"/>
+   </bf:HeldItem>
+   <bf:Title rdf:about="http://example.org/14507819title6">
+      <bf:titleValue>Bible.</bf:titleValue>
+      <bf:partTitle>Esther.</bf:partTitle>
+   </bf:Title>
+   <bf:Language rdf:about="http://example.org/14507819language7">
+      <bf:languageOfPart>Hebew.</bf:languageOfPart>
+   </bf:Language>
+   <bf:Agent rdf:about="http://example.org/14507819agent13">
+      <bf:label/>
+   </bf:Agent>
+   <bf:Person rdf:about="http://example.org/14507819person18">
+      <bf:label>Korman, Abraham, 1917-2001.</bf:label>
+      <bf:authorizedAccessPoint>Korman, Abraham, 1917-2001.</bf:authorizedAccessPoint>
+      <bf:authorizedAccessPoint xml:lang="he-hebr">קורמן, אברהם.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>Korman, Abraham, 1917-2001.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Person>
+   <bf:Title rdf:about="http://example.org/14507819title19">
+      <bf:label>Megilat Ester : ʻi. p. tekhelet  Avraham / me-et Avraham Ḳorman.</bf:label>
+      <bf:titleValue>Megilat Ester :</bf:titleValue>
+      <bf:subtitle>ʻi. p. tekhelet Avraham </bf:subtitle>
+      <bf:titleValue xml:lang="he-hebr">מגילת אסתר ע״פ תכלת אברהם</bf:titleValue>
+   </bf:Title>
+   <bf:Title rdf:about="http://example.org/14507819title20">
+      <bf:titleType>Title on prelim. p.:</bf:titleType>
+      <bf:label>Title on prelim. p.: Commentary on the Book of Esther</bf:label>
+      <bf:titleValue>Commentary on the Book of Esther</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/translationOf/14507819.ttl
+++ b/spec/fixtures/loc/m2b-properties/translationOf/14507819.ttl
@@ -1,0 +1,121 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/14507819annotation15> a bf:Annotation;
+   bf:annotates <http://example.org/14507819>;
+   bf:changeDate "2013-05-31T11:56";
+   bf:derivedFrom <http://example.org/14507819.marcxml.xml>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlcr>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/14507819helditem36> a bf:HeldItem;
+   bf:holdingFor <http://example.org/14507819instance16>;
+   bf:label "BS1372 .K68 2006";
+   bf:shelfMarkLcc "BS1372 .K68 2006" .
+
+<http://example.org/14507819agent13> a bf:Agent;
+   bf:label "" .
+
+<http://example.org/14507819instance16> a bf:Instance,
+     bf:Monograph;
+   bf:dimensions "23 cm.";
+   bf:edition "מהדורה מתוקנת ומורחבת."@he-hebr,
+     "Mahad. metuḳenet u-murḥevet.";
+   bf:extent "58 p. :";
+   bf:illustrationNote "ill.;";
+   bf:instanceOf <http://example.org/14507819>;
+   bf:instanceTitle <http://example.org/14507819title19>;
+   bf:isbn10 <http://isbn.example.org/9659048653>;
+   bf:isbn13 <http://isbn.example.org/9789659048656>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "2006473232"
+   ];
+   bf:modeOfIssuance "single unit";
+   bf:providerStatement "Tel Aviv : Yorshe Ḳorman Avraham, 766 i.e. 2006";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "[766 i.e. 2006]",
+       "766 i.e. 2006"@he-hebr;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "Yorshe Ḳorman Avraham",
+         "יורשי קורמן אברהם"@he-hebr
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Tel Aviv ",
+         "תל אביב :"@he-hebr
+     ]
+   ];
+   bf:responsibilityStatement "מאת קורמן אברהם."@he-hebr;
+   bf:systemNumber [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:systemNumber;
+     bf:identifierValue "(CStRLIN)DCLH06-B2388"
+   ];
+   bf:titleStatement "Megilat Ester : ʻi. p. tekhelet Avraham";
+   bf:titleVariation <http://example.org/14507819title20> .
+
+<http://example.org/14507819language7> a bf:Language;
+   bf:languageOfPart "Hebew." .
+
+<http://example.org/14507819person18> a bf:Person;
+   bf:authorizedAccessPoint "Korman, Abraham, 1917-2001.",
+     "קורמן, אברהם."@he-hebr;
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "Korman, Abraham, 1917-2001."
+   ];
+   bf:label "Korman, Abraham, 1917-2001." .
+
+<http://example.org/14507819title19> a bf:Title;
+   bf:label "Megilat Ester : ʻi. p. tekhelet  Avraham / me-et Avraham Ḳorman.";
+   bf:subtitle "ʻi. p. tekhelet Avraham ";
+   bf:titleValue "Megilat Ester :",
+     "מגילת אסתר ע״פ תכלת אברהם"@he-hebr .
+
+<http://example.org/14507819title20> a bf:Title;
+   bf:label "Title on prelim. p.: Commentary on the Book of Esther";
+   bf:titleType "Title on prelim. p.:";
+   bf:titleValue "Commentary on the Book of Esther" .
+
+<http://example.org/14507819title6> a bf:Title;
+   bf:partTitle "Esther.";
+   bf:titleValue "Bible." .
+
+<http://example.org/14507819work12> a bf:Work;
+   bf:authorizedAccessPoint "Tekhelet Avraham.",
+     "תכלת אברהם."@he-hebr;
+   bf:title "Tekhelet Avraham." .
+
+<http://example.org/14507819work13> a bf:Work;
+   bf:authorizedAccessPoint "Korman, Abraham, 1917-2001. Tekhelet Avraham.",
+     "קורמן, אברהם. תכלת אברהם."@he-hebr;
+   bf:contributor <http://example.org/14507819person18>;
+   bf:title "Tekhelet Avraham." .
+
+<http://example.org/14507819work8> a bf:Work;
+   bf:authorizedAccessPoint "Bible. 2006.";
+   bf:contributor <http://example.org/14507819agent13>;
+   bf:title "Bible. 2006.";
+   mads:authoritativeLabel "Bible. 2006." .
+
+<http://example.org/14507819> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "Bible. Esther. Hebew. 2006",
+     "kormanabraham19172001bibleestherhebew2006hebworktext"@x-bf-hash;
+   bf:classificationLcc <http://id.loc.gov/authorities/classification/BS1372>;
+   bf:hasPart <http://example.org/14507819work12>,
+     <http://example.org/14507819work13>;
+   bf:language <http://example.org/14507819language7>,
+     <http://id.loc.gov/vocabulary/languages/heb>;
+   bf:originDate "2006.";
+   bf:translationOf <http://example.org/14507819work8>;
+   bf:workTitle <http://example.org/14507819title6>;
+   mads:authoritativeLabel "Bible. Esther. Hebew. 2006." .

--- a/spec/fixtures/loc/m2b-properties/unionOf/11267155.marcxml
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11267155.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01239cas a22003377a 4500</leader>
   <controlfield tag="001">11267155</controlfield>
   <controlfield tag="005">20130302155721.0</controlfield>
@@ -99,4 +99,4 @@
     <subfield code="h">Newspaper 7002</subfield>
     <subfield code="w">SERIALS</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11267155</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/unionOf/11267155.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11267155.rdfxml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11267155">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>The Mendon globe-leader.The Mendon globe-leader</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11267155title5"/>
+      <bf:title xml:lang="x-bf-sort">Mendon globe-leader</bf:title>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11267155topic8"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us-mi"/>
+      <bf:unionOf rdf:resource="http://example.org/11267155work10"/>
+      <bf:unionOf rdf:resource="http://example.org/11267155work11"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">mendonglobeleaderengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11267155work10">
+      <bf:title>Weekly globe (Mendon, Mich.)</bf:title>
+      <bf:authorizedAccessPoint>Weekly globe (Mendon, Mich.)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn00062696"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/45216255"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11267155work11">
+      <bf:title>Mendon leader</bf:title>
+      <bf:authorizedAccessPoint>Mendon leader</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sn00062691"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/45216336"/>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11267155instance14">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11267155title17"/>
+      <bf:title xml:lang="x-bf-sort">Mendon globe-leader</bf:title>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>R.L. Foltz</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Mendon, Mich. </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>60 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>The Mendon globe-leader.</bf:titleStatement>
+      <bf:providerStatement>Mendon, Mich. : R.L. Foltz</bf:providerStatement>
+      <bf:frequencyNote>Weekly</bf:frequencyNote>
+      <bf:note>"Independent." Cf. Ayer, 1970.</bf:note>
+      <bf:note>"Saint Joseph County's most progressive weekly."</bf:note>
+      <bf:note>Formed by the union of: Weekly globe (Mendon, Mich.), and: Mendon leader.</bf:note>
+      <bf:note>Description based on: Apr. 12, 1945.</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>sn 83016407</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/09798434"/>
+      <bf:serialFirstIssue>Began in 1912?</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11267155"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11267155annotation13">
+      <bf:derivedFrom rdf:resource="http://example.org/11267155.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/mhn"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/oclco"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/msc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-03-02T15:57</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11267155"/>
+   </bf:Annotation>
+   <bf:Title rdf:about="http://example.org/11267155title5">
+      <bf:label>The Mendon globe-leader.</bf:label>
+      <bf:titleValue>The Mendon globe-leader</bf:titleValue>
+   </bf:Title>
+   <bf:Topic rdf:about="http://example.org/11267155topic8">
+      <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic"/>
+      <bf:authorizedAccessPoint>United States. Michigan. Saint Joseph. Mendon.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Michigan. Saint Joseph. Mendon.</madsrdf:authoritativeLabel>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Country>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+               </madsrdf:Country>
+               <madsrdf:State>
+                  <madsrdf:authoritativeLabel>Michigan</madsrdf:authoritativeLabel>
+               </madsrdf:State>
+               <madsrdf:County>
+                  <madsrdf:authoritativeLabel>Saint Joseph</madsrdf:authoritativeLabel>
+               </madsrdf:County>
+               <madsrdf:City>
+                  <madsrdf:authoritativeLabel>Mendon.</madsrdf:authoritativeLabel>
+               </madsrdf:City>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Title rdf:about="http://example.org/11267155title17">
+      <bf:label>The Mendon globe-leader.</bf:label>
+      <bf:titleValue>The Mendon globe-leader</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/unionOf/11267155.ttl
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11267155.ttl
@@ -1,0 +1,106 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11267155annotation13> a bf:Annotation;
+   bf:annotates <http://example.org/11267155>;
+   bf:changeDate "2013-03-02T15:57";
+   bf:derivedFrom <http://example.org/11267155.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/msc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/mhn>,
+     <http://id.loc.gov/vocabulary/organizations/oclco>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/dlc>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11267155instance14> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "60 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Weekly";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11267155>;
+   bf:instanceTitle <http://example.org/11267155title17>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "sn 83016407"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "\"Independent.\" Cf. Ayer, 1970.",
+     "\"Saint Joseph County's most progressive weekly.\"",
+     "Formed by the union of: Weekly globe (Mendon, Mich.), and: Mendon leader.",
+     "Description based on: Apr. 12, 1945.";
+   bf:providerStatement "Mendon, Mich. : R.L. Foltz";
+   bf:publication [
+     a bf:Provider;
+     bf:providerName [
+       a bf:Organization;
+       bf:label "R.L. Foltz"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Mendon, Mich. "
+     ]
+   ];
+   bf:serialFirstIssue "Began in 1912?";
+   bf:systemNumber <http://www.worldcat.org/oclc/09798434>;
+   bf:title "Mendon globe-leader"@x-bf-sort;
+   bf:titleStatement "The Mendon globe-leader." .
+
+<http://example.org/11267155title17> a bf:Title;
+   bf:label "The Mendon globe-leader.";
+   bf:titleValue "The Mendon globe-leader" .
+
+<http://example.org/11267155title5> a bf:Title;
+   bf:label "The Mendon globe-leader.";
+   bf:titleValue "The Mendon globe-leader" .
+
+<http://example.org/11267155topic8> a bf:Topic,
+     mads:HierarchicalGeographic;
+   bf:authorizedAccessPoint "United States. Michigan. Saint Joseph. Mendon.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Michigan. Saint Joseph. Mendon.";
+     mads:componentList ([
+         a mads:Country;
+         mads:authoritativeLabel "United States"
+       ] [
+         a mads:State;
+         mads:authoritativeLabel "Michigan"
+       ] [
+         a mads:County;
+         mads:authoritativeLabel "Saint Joseph"
+       ] [
+         a mads:City;
+         mads:authoritativeLabel "Mendon."
+       ])
+   ] .
+
+<http://example.org/11267155work10> a bf:Work;
+   bf:authorizedAccessPoint "Weekly globe (Mendon, Mich.)";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn00062696>;
+   bf:systemNumber <http://www.worldcat.org/oclc/45216255>;
+   bf:title "Weekly globe (Mendon, Mich.)" .
+
+<http://example.org/11267155work11> a bf:Work;
+   bf:authorizedAccessPoint "Mendon leader";
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sn00062691>;
+   bf:systemNumber <http://www.worldcat.org/oclc/45216336>;
+   bf:title "Mendon leader" .
+
+<http://example.org/11267155> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "The Mendon globe-leader.The Mendon globe-leader",
+     "mendonglobeleaderengworktext"@x-bf-hash;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:subject <http://example.org/11267155topic8>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us-mi>;
+   bf:title "Mendon globe-leader"@x-bf-sort;
+   bf:unionOf <http://example.org/11267155work10>,
+     <http://example.org/11267155work11>;
+   bf:workTitle <http://example.org/11267155title5> .

--- a/spec/fixtures/loc/m2b-properties/unionOf/11402156.marcxml
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11402156.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02301cas a22004575a 4500</leader>
   <controlfield tag="001">11402156</controlfield>
   <controlfield tag="005">20130113161355.0</controlfield>
@@ -143,4 +143,4 @@
     <subfield code="b">B/L</subfield>
     <subfield code="w">SERLOC</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=11402156</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/unionOf/11402156.rdfxml
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11402156.rdfxml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:relators="http://id.loc.gov/vocabulary/relators/"
+         xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+         xmlns:bf2="http://bibframe.org/vocab2/"
+         xmlns:bf="http://bibframe.org/vocab/"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <bf:Work rdf:about="http://example.org/11402156">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Text"/>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration. A brief history of the rural electric and telephone programs and report of the administrator.A brief history of the rural electric and telephone programs and report of the administrator</bf:authorizedAccessPoint>
+      <bf:workTitle rdf:resource="http://example.org/11402156title5"/>
+      <bf:title xml:lang="x-bf-sort">brief history of the rural electric and telephone programs and report of the administrator</bf:title>
+      <bf:creator rdf:resource="http://example.org/11402156jurisdiction7"/>
+      <bf:language rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:subject rdf:resource="http://example.org/11402156organization9"/>
+      <bf:subject rdf:resource="http://example.org/11402156topic10"/>
+      <bf:subject rdf:resource="http://example.org/11402156topic11"/>
+      <bf:subject rdf:resource="http://id.loc.gov/vocabulary/geographicAreas/n-us"/>
+      <bf:classification rdf:resource="http://example.org/11402156classification13"/>
+      <bf:unionOf rdf:resource="http://example.org/11402156work14"/>
+      <bf:continuedBy rdf:resource="http://example.org/11402156work15"/>
+      <bf:continuedBy rdf:resource="http://example.org/11402156work16"/>
+      <bf:series rdf:resource="http://example.org/11402156work17"/>
+      <bf:authorizedAccessPoint xml:lang="x-bf-hash">unitedstatesruralelectrificationadministrationbriefhistoryoftheruralelectricandtelephoneprogramsandreportoftheadministratorengworktext</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11402156work14">
+      <bf:title>Report of the administrator</bf:title>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration. Report of the administrator</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/sc79002881"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/1780531"/>
+      <bf:contributor rdf:resource="http://example.org/11402156agent20"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11402156work15">
+      <bf:title>Brief history of the rural electric and telephone programs</bf:title>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration. Brief history of the rural electric and telephone programs</bf:authorizedAccessPoint>
+      <bf:contributor rdf:resource="http://example.org/11402156agent19"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11402156work16">
+      <bf:title>Report of the administrator (1994)</bf:title>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration. Report of the administrator (1994)</bf:authorizedAccessPoint>
+      <bf:lccn rdf:resource="http://id.loc.gov/authorities/test/identifiers/lccn/95644644"/>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/32521660"/>
+      <bf:contributor rdf:resource="http://example.org/11402156agent22"/>
+   </bf:Work>
+   <bf:Work rdf:about="http://example.org/11402156work17">
+      <bf:title>Informational publication</bf:title>
+      <bf:authorizedAccessPoint>Informational publication</bf:authorizedAccessPoint>
+   </bf:Work>
+   <bf:Instance rdf:about="http://example.org/11402156instance20">
+      <rdf:type rdf:resource="http://bibframe.org/vocab/Serial"/>
+      <bf:instanceTitle rdf:resource="http://example.org/11402156title23"/>
+      <bf:title xml:lang="x-bf-sort">brief history of the rural electric and telephone programs and report of the administrator</bf:title>
+      <bf:publication>
+         <bf:Provider>
+            <bf:providerName>
+               <bf:Organization>
+                  <bf:label>U.S. Dept. of Agriculture, Rural Electrification Administration</bf:label>
+               </bf:Organization>
+            </bf:providerName>
+            <bf:providerPlace>
+               <bf:Place>
+                  <bf:label>Washington, DC </bf:label>
+               </bf:Place>
+            </bf:providerPlace>
+            <bf:providerDate>1992-</bf:providerDate>
+         </bf:Provider>
+      </bf:publication>
+      <bf:modeOfIssuance>serial</bf:modeOfIssuance>
+      <bf:otherPhysicalFormat rdf:resource="http://example.org/11402156instance27"/>
+      <bf:extent>v. :</bf:extent>
+      <bf:dimensions>28 cm.</bf:dimensions>
+      <bf:illustrationNote>ill. ;</bf:illustrationNote>
+      <bf:titleStatement>A brief history of the rural electric and telephone programs and report of the administrator.</bf:titleStatement>
+      <bf:providerStatement>Washington, DC : U.S. Dept. of Agriculture, Rural Electrification Administration, 1992-</bf:providerStatement>
+      <bf:frequencyNote>Annual</bf:frequencyNote>
+      <bf:note>Title from cover.</bf:note>
+      <bf:note>Distributed to depository libraries on microfiche.</bf:note>
+      <bf:note>Merger of: United States. Rural Electrification Administration. Report of the administrator; and: United States. Rural Electrification Administration. Brief history of the rural electric and telephone programs.</bf:note>
+      <bf:note>SERBIB/SERLOC merged record</bf:note>
+      <bf:lccn>
+         <bf:Identifier>
+            <bf:identifierValue>92642101</bf:identifierValue>
+            <bf:identifierScheme rdf:resource="http://id.loc.gov/vocabulary/identifiers/lccn"/>
+         </bf:Identifier>
+      </bf:lccn>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/26018750"/>
+      <bf:serialFirstIssue>Fiscal year 1991</bf:serialFirstIssue>
+      <bf:instanceOf rdf:resource="http://example.org/11402156"/>
+   </bf:Instance>
+   <bf:Instance rdf:about="http://example.org/11402156instance27">
+      <bf:title>A brief history of the rural electric and telephone programs and report of the administrator.Microfiche</bf:title>
+      <bf:systemNumber rdf:resource="http://www.worldcat.org/oclc/26940710"/>
+   </bf:Instance>
+   <bf:Annotation rdf:about="http://example.org/11402156annotation19">
+      <bf:derivedFrom rdf:resource="http://example.org/11402156.marcxml.xml"/>
+      <bf:descriptionSource rdf:resource="http://id.loc.gov/vocabulary/organizations/deei"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/nic"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dgpo"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/dlc"/>
+      <bf:descriptionModifier rdf:resource="http://id.loc.gov/vocabulary/organizations/ocolc"/>
+      <bf:descriptionLanguage rdf:resource="http://id.loc.gov/vocabulary/languages/eng"/>
+      <bf:descriptionAuthentication rdf:resource="http://id.loc.gov/vocabulary/descriptionAuthentication/pcc"/>
+      <bf:descriptionConventions rdf:resource="http://id.loc.gov/vocabulary/descriptionConventions/aacr2"/>
+      <bf:generationProcess>DLC transform-tool:2015-07-23-T17:01:00</bf:generationProcess>
+      <bf:changeDate>2013-01-13T16:13</bf:changeDate>
+      <bf:annotates rdf:resource="http://example.org/11402156"/>
+   </bf:Annotation>
+   <bf:Title rdf:about="http://example.org/11402156title5">
+      <bf:label>A brief history of the rural electric and telephone programs and report of the administrator.</bf:label>
+      <bf:titleValue>A brief history of the rural electric and telephone programs and report of the administrator</bf:titleValue>
+   </bf:Title>
+   <bf:Jurisdiction rdf:about="http://example.org/11402156jurisdiction7">
+      <bf:label>United States. Rural Electrification Administration.</bf:label>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Rural Electrification Administration.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Jurisdiction>
+   <bf:Organization rdf:about="http://example.org/11402156organization9">
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration--Periodicals.</bf:authorizedAccessPoint>
+      <bf:label>United States. Rural Electrification Administration--Periodicals.</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>United States. Rural Electrification Administration--Periodicals.</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:CorporateName>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States. Rural Electrification Administration</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>United States.</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                     <madsrdf:NameElement>
+                        <madsrdf:elementValue>Rural Electrification Administration</madsrdf:elementValue>
+                     </madsrdf:NameElement>
+                  </madsrdf:elementList>
+               </madsrdf:CorporateName>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Organization>
+   <bf:Topic rdf:about="http://example.org/11402156topic10">
+      <bf:authorizedAccessPoint>Rural electrification--United States--History--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Rural electrification--United States--History--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Rural electrification--United States--History--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Rural electrification</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Rural electrification</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>History</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>History</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Topic rdf:about="http://example.org/11402156topic11">
+      <bf:authorizedAccessPoint>Rural telephone--United States--History--Periodicals</bf:authorizedAccessPoint>
+      <bf:label>Rural telephone--United States--History--Periodicals</bf:label>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+            <madsrdf:authoritativeLabel>Rural telephone--United States--History--Periodicals</madsrdf:authoritativeLabel>
+            <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+            <madsrdf:componentList rdf:parseType="Collection">
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Rural telephone</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>Rural telephone</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:Geographic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>United States</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GeographicElement>
+                        <madsrdf:elementValue>United States</madsrdf:elementValue>
+                     </madsrdf:GeographicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Geographic>
+               <madsrdf:Topic>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>History</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:TopicElement>
+                        <madsrdf:elementValue>History</madsrdf:elementValue>
+                     </madsrdf:TopicElement>
+                  </madsrdf:elementList>
+               </madsrdf:Topic>
+               <madsrdf:GenreForm>
+                  <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                  <madsrdf:authoritativeLabel>Periodicals</madsrdf:authoritativeLabel>
+                  <madsrdf:elementList rdf:parseType="Collection">
+                     <madsrdf:GenreFormElement>
+                        <madsrdf:elementValue>Periodicals.</madsrdf:elementValue>
+                     </madsrdf:GenreFormElement>
+                  </madsrdf:elementList>
+               </madsrdf:GenreForm>
+            </madsrdf:componentList>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Topic>
+   <bf:Classification rdf:about="http://example.org/11402156classification13">
+      <bf:classificationNumber>A 68.1</bf:classificationNumber>
+      <bf:classificationScheme>SUDOC</bf:classificationScheme>
+   </bf:Classification>
+   <bf:Agent rdf:about="http://example.org/11402156agent20">
+      <bf:label>United States. Rural Electrification Administration.</bf:label>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Rural Electrification Administration.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/11402156agent19">
+      <bf:label>United States. Rural Electrification Administration.</bf:label>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Rural Electrification Administration.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Agent rdf:about="http://example.org/11402156agent22">
+      <bf:label>United States. Rural Electrification Administration.</bf:label>
+      <bf:authorizedAccessPoint>United States. Rural Electrification Administration.</bf:authorizedAccessPoint>
+      <bf:hasAuthority>
+         <madsrdf:Authority>
+            <madsrdf:authoritativeLabel>United States. Rural Electrification Administration.</madsrdf:authoritativeLabel>
+         </madsrdf:Authority>
+      </bf:hasAuthority>
+   </bf:Agent>
+   <bf:Title rdf:about="http://example.org/11402156title23">
+      <bf:label>A brief history of the rural electric and telephone programs and report of the administrator.</bf:label>
+      <bf:titleValue>A brief history of the rural electric and telephone programs and report of the administrator</bf:titleValue>
+   </bf:Title>
+</rdf:RDF>

--- a/spec/fixtures/loc/m2b-properties/unionOf/11402156.ttl
+++ b/spec/fixtures/loc/m2b-properties/unionOf/11402156.ttl
@@ -1,0 +1,261 @@
+@prefix bf: <http://bibframe.org/vocab/> .
+@prefix loc_ids: <http://id.loc.gov/vocabulary/identifiers/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/11402156annotation19> a bf:Annotation;
+   bf:annotates <http://example.org/11402156>;
+   bf:changeDate "2013-01-13T16:13";
+   bf:derivedFrom <http://example.org/11402156.marcxml.xml>;
+   bf:descriptionAuthentication <http://id.loc.gov/vocabulary/descriptionAuthentication/pcc>;
+   bf:descriptionConventions <http://id.loc.gov/vocabulary/descriptionConventions/aacr2>;
+   bf:descriptionLanguage <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:descriptionModifier <http://id.loc.gov/vocabulary/organizations/dlc>,
+     <http://id.loc.gov/vocabulary/organizations/nic>,
+     <http://id.loc.gov/vocabulary/organizations/dgpo>,
+     <http://id.loc.gov/vocabulary/organizations/ocolc>;
+   bf:descriptionSource <http://id.loc.gov/vocabulary/organizations/deei>;
+   bf:generationProcess "DLC transform-tool:2015-07-23-T17:01:00" .
+
+<http://example.org/11402156instance20> a bf:Instance,
+     bf:Serial;
+   bf:dimensions "28 cm.";
+   bf:extent "v. :";
+   bf:frequencyNote "Annual";
+   bf:illustrationNote "ill. ;";
+   bf:instanceOf <http://example.org/11402156>;
+   bf:instanceTitle <http://example.org/11402156title23>;
+   bf:lccn [
+     a bf:Identifier;
+     bf:identifierScheme loc_ids:lccn;
+     bf:identifierValue "92642101"
+   ];
+   bf:modeOfIssuance "serial";
+   bf:note "Title from cover.",
+     "Distributed to depository libraries on microfiche.",
+     "Merger of: United States. Rural Electrification Administration. Report of the administrator; and: United States. Rural Electrification Administration. Brief history of the rural electric and telephone programs.",
+     "SERBIB/SERLOC merged record";
+   bf:otherPhysicalFormat <http://example.org/11402156instance27>;
+   bf:providerStatement "Washington, DC : U.S. Dept. of Agriculture, Rural Electrification Administration, 1992-";
+   bf:publication [
+     a bf:Provider;
+     bf:providerDate "1992-";
+     bf:providerName [
+       a bf:Organization;
+       bf:label "U.S. Dept. of Agriculture, Rural Electrification Administration"
+     ];
+     bf:providerPlace [
+       a bf:Place;
+       bf:label "Washington, DC "
+     ]
+   ];
+   bf:serialFirstIssue "Fiscal year 1991";
+   bf:systemNumber <http://www.worldcat.org/oclc/26018750>;
+   bf:title "brief history of the rural electric and telephone programs and report of the administrator"@x-bf-sort;
+   bf:titleStatement "A brief history of the rural electric and telephone programs and report of the administrator." .
+
+<http://example.org/11402156agent19> a bf:Agent;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Rural Electrification Administration."
+   ];
+   bf:label "United States. Rural Electrification Administration." .
+
+<http://example.org/11402156agent20> a bf:Agent;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Rural Electrification Administration."
+   ];
+   bf:label "United States. Rural Electrification Administration." .
+
+<http://example.org/11402156agent22> a bf:Agent;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Rural Electrification Administration."
+   ];
+   bf:label "United States. Rural Electrification Administration." .
+
+<http://example.org/11402156classification13> a bf:Classification;
+   bf:classificationNumber "A 68.1";
+   bf:classificationScheme "SUDOC" .
+
+<http://example.org/11402156instance27> a bf:Instance;
+   bf:systemNumber <http://www.worldcat.org/oclc/26940710>;
+   bf:title "A brief history of the rural electric and telephone programs and report of the administrator.Microfiche" .
+
+<http://example.org/11402156jurisdiction7> a bf:Jurisdiction;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration.";
+   bf:hasAuthority [
+     a mads:Authority;
+     mads:authoritativeLabel "United States. Rural Electrification Administration."
+   ];
+   bf:label "United States. Rural Electrification Administration." .
+
+<http://example.org/11402156organization9> a bf:Organization;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration--Periodicals.";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "United States. Rural Electrification Administration--Periodicals.";
+     mads:componentList ([
+         a mads:CorporateName,
+           mads:Authority;
+         mads:authoritativeLabel "United States. Rural Electrification Administration";
+         mads:elementList ([
+             a mads:NameElement;
+             mads:elementValue "United States."
+           ] [
+             a mads:NameElement;
+             mads:elementValue "Rural Electrification Administration"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "United States. Rural Electrification Administration--Periodicals." .
+
+<http://example.org/11402156title23> a bf:Title;
+   bf:label "A brief history of the rural electric and telephone programs and report of the administrator.";
+   bf:titleValue "A brief history of the rural electric and telephone programs and report of the administrator" .
+
+<http://example.org/11402156title5> a bf:Title;
+   bf:label "A brief history of the rural electric and telephone programs and report of the administrator.";
+   bf:titleValue "A brief history of the rural electric and telephone programs and report of the administrator" .
+
+<http://example.org/11402156topic10> a bf:Topic;
+   bf:authorizedAccessPoint "Rural electrification--United States--History--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Rural electrification--United States--History--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Rural electrification";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Rural electrification"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "History";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "History"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Rural electrification--United States--History--Periodicals" .
+
+<http://example.org/11402156topic11> a bf:Topic;
+   bf:authorizedAccessPoint "Rural telephone--United States--History--Periodicals";
+   bf:hasAuthority [
+     a mads:Authority,
+       mads:ComplexSubject;
+     mads:authoritativeLabel "Rural telephone--United States--History--Periodicals";
+     mads:componentList ([
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "Rural telephone";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "Rural telephone"
+           ])
+       ] [
+         a mads:Geographic,
+           mads:Authority;
+         mads:authoritativeLabel "United States";
+         mads:elementList ([
+             a mads:GeographicElement;
+             mads:elementValue "United States"
+           ])
+       ] [
+         a mads:Topic,
+           mads:Authority;
+         mads:authoritativeLabel "History";
+         mads:elementList ([
+             a mads:TopicElement;
+             mads:elementValue "History"
+           ])
+       ] [
+         a mads:GenreForm,
+           mads:Authority;
+         mads:authoritativeLabel "Periodicals";
+         mads:elementList ([
+             a mads:GenreFormElement;
+             mads:elementValue "Periodicals."
+           ])
+       ]);
+     mads:isMemberOfMADSScheme <http://id.loc.gov/authorities/subjects>
+   ];
+   bf:label "Rural telephone--United States--History--Periodicals" .
+
+<http://example.org/11402156work14> a bf:Work;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration. Report of the administrator";
+   bf:contributor <http://example.org/11402156agent20>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/sc79002881>;
+   bf:systemNumber <http://www.worldcat.org/oclc/1780531>;
+   bf:title "Report of the administrator" .
+
+<http://example.org/11402156work15> a bf:Work;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration. Brief history of the rural electric and telephone programs";
+   bf:contributor <http://example.org/11402156agent19>;
+   bf:title "Brief history of the rural electric and telephone programs" .
+
+<http://example.org/11402156work16> a bf:Work;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration. Report of the administrator (1994)";
+   bf:contributor <http://example.org/11402156agent22>;
+   bf:lccn <http://id.loc.gov/authorities/test/identifiers/lccn/95644644>;
+   bf:systemNumber <http://www.worldcat.org/oclc/32521660>;
+   bf:title "Report of the administrator (1994)" .
+
+<http://example.org/11402156work17> a bf:Work;
+   bf:authorizedAccessPoint "Informational publication";
+   bf:title "Informational publication" .
+
+<http://example.org/11402156> a bf:Work,
+     bf:Text;
+   bf:authorizedAccessPoint "United States. Rural Electrification Administration. A brief history of the rural electric and telephone programs and report of the administrator.A brief history of the rural electric and telephone programs and report of the administrator",
+     "unitedstatesruralelectrificationadministrationbriefhistoryoftheruralelectricandtelephoneprogramsandreportoftheadministratorengworktext"@x-bf-hash;
+   bf:classification <http://example.org/11402156classification13>;
+   bf:continuedBy <http://example.org/11402156work15>,
+     <http://example.org/11402156work16>;
+   bf:creator <http://example.org/11402156jurisdiction7>;
+   bf:language <http://id.loc.gov/vocabulary/languages/eng>;
+   bf:series <http://example.org/11402156work17>;
+   bf:subject <http://example.org/11402156organization9>,
+     <http://example.org/11402156topic10>,
+     <http://example.org/11402156topic11>,
+     <http://id.loc.gov/vocabulary/geographicAreas/n-us>;
+   bf:title "brief history of the rural electric and telephone programs and report of the administrator"@x-bf-sort;
+   bf:unionOf <http://example.org/11402156work14>;
+   bf:workTitle <http://example.org/11402156title5> .

--- a/spec/fixtures/loc/m2b-properties/upc/12241297.marcxml
+++ b/spec/fixtures/loc/m2b-properties/upc/12241297.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01873cjm a22003731a 4500</leader>
   <controlfield tag="001">12241297</controlfield>
   <controlfield tag="005">20121019141547.0</controlfield>
@@ -122,4 +122,4 @@
     <subfield code="c">OCLC</subfield>
     <subfield code="e">srreplace 2003-01</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=12241297</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/uri/16530652.marcxml
+++ b/spec/fixtures/loc/m2b-properties/uri/16530652.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>03995ckd a2200637 a 4500</leader>
   <controlfield tag="001">16530652</controlfield>
   <controlfield tag="005">20110616095858.0</controlfield>
@@ -212,4 +212,4 @@
     <subfield code="b">c-P&amp;P</subfield>
     <subfield code="m">(H)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=16530652</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/urn/17439166.marcxml
+++ b/spec/fixtures/loc/m2b-properties/urn/17439166.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02195cam a2200433 a 4500</leader>
   <controlfield tag="001">17439166</controlfield>
   <controlfield tag="005">20120824093444.0</controlfield>
@@ -137,4 +137,4 @@
   <datafield tag="952" ind1=" " ind2=" ">
     <subfield code="a">DR555.7.V65 1788 Copy 1 formerly part of the YA collection:  YA 833.  he04 2012-08-23</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=17439166</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/videorecordingNumber/13488078.marcxml
+++ b/spec/fixtures/loc/m2b-properties/videorecordingNumber/13488078.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01055cgm a22002655a 4500</leader>
   <controlfield tag="001">13488078</controlfield>
   <controlfield tag="005">20040211160725.0</controlfield>
@@ -72,4 +72,4 @@
   <datafield tag="520" ind1=" " ind2=" ">
     <subfield code="a">On a giant Matzah Ball in outer space lives a family of funny, furry, Jewish aliens. When a menorah crash lands the 9-year-old is puzzled as to what it is because they have not kept up with traditions. He looks to Earth to see kids celebrating Chanukah.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=13488078</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/workTitle/10452973.marcxml
+++ b/spec/fixtures/loc/m2b-properties/workTitle/10452973.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01081cam a2200265 i 4500</leader>
   <controlfield tag="001">10452973</controlfield>
   <controlfield tag="005">20140305154731.0</controlfield>
@@ -84,4 +84,4 @@
     <subfield code="m">Russian Imperial Coll</subfield>
     <subfield code="w">PREM</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=10452973</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/workTitle/15798171.marcxml
+++ b/spec/fixtures/loc/m2b-properties/workTitle/15798171.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01591cam a2200433 a 4500</leader>
   <controlfield tag="001">15798171</controlfield>
   <controlfield tag="005">20150728145155.0</controlfield>
@@ -140,4 +140,4 @@
     <subfield code="d">1942-</subfield>
     <subfield code="e">editor.</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=15798171</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>

--- a/spec/fixtures/loc/m2b-properties/workTitle/5178263.marcxml
+++ b/spec/fixtures/loc/m2b-properties/workTitle/5178263.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+<record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>02709cam a2200565 a 4500</leader>
   <controlfield tag="001">5178263</controlfield>
   <controlfield tag="005">20090701095949.0</controlfield>
@@ -208,4 +208,4 @@
     <subfield code="e">1.1</subfield>
     <subfield code="f">See field: 245(1)</subfield>
   </datafield>
-</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0</zs:version><zs:query>rec.id=5178263</zs:query><zs:maximumRecords>1</zs:maximumRecords><zs:recordXMLEscaping>xml</zs:recordXMLEscaping><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>
+</record>


### PR DESCRIPTION
and a few tweaks to the docs for the LoC record fetching code.

Sed commands used to get rid of zs wrapper elements in LoC marcxml:

```
sed -i '' 's/<zs:searchRetrieveResponse xmlns:zs="http:\/\/docs.oasis-open.org\/ns\/search-ws\/sruResponse"><zs:numberOfRecords>1<\/zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml<\/zs:recordSchema><zs:recordXMLEscaping>xml<\/zs:recordXMLEscaping><zs:recordData>//g' spec/fixtures/loc/m2b-*/*/*.marcxml
sed -i '' 's/<\/zs:recordData><zs:recordPosition>1<\/zs:recordPosition><\/zs:record><\/zs:records><zs:echoedSearchRetrieveRequest><zs:version>2.0<\/zs:version><zs:query>rec.id=.{1,8}<\/zs:query><zs:maximumRecords>1<\/zs:maximumRecords><zs:recordXMLEscaping>xml<\/zs:recordXMLEscaping><zs:recordSchema>marcxml<\/zs:recordSchema><\/zs:echoedSearchRetrieveRequest><\/zs:searchRetrieveResponse>//g' spec/fixtures/loc/m2b-*/*/*.marcxml
```

Sed commands used to shorten prefixes in ttl:

```
sed -i '' 's/bibframe:/bf:/g' spec/fixtures/loc/m2b-*/*/*.ttl
sed -i '' 's/identifiers:/loc_ids:/g' spec/fixtures/loc/m2b-*/*/*.ttl
```
